### PR TITLE
Verify certificate and application ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ test.py
 .vscode
 
 .env
+*.ini

--- a/kodi.py
+++ b/kodi.py
@@ -89,8 +89,8 @@ def SendCommand(command):
   USER = os.getenv('KODI_USERNAME', 'kodi')
   PASS = os.getenv('KODI_PASSWORD', 'kodi')
 
-  print KODI
-  
+  print "Sending request to %s:%d" % (KODI, PORT)
+
   url = "http://%s:%d/jsonrpc" % (KODI, PORT)
 
   try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,7 @@ requests
 gunicorn
 pycountry
 ConfigParser
+aniso8601
+six
+OpenSSL
 yaep

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 requests
 gunicorn
+yaep
 pycountry
 ConfigParser
-aniso8601
-six
-OpenSSL
-yaep

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
 gunicorn
 pycountry
+ConfigParser
 yaep

--- a/requirements_verify.txt
+++ b/requirements_verify.txt
@@ -1,0 +1,3 @@
+aniso8601
+six
+OpenSSL

--- a/verifier.py
+++ b/verifier.py
@@ -1,0 +1,67 @@
+import os
+import base64
+import posixpath
+from datetime import datetime
+from six.moves.urllib.parse import urlparse
+from six.moves.urllib.request import urlopen
+
+from OpenSSL import crypto
+
+
+class VerificationError(Exception): pass
+
+
+def load_certificate(cert_url):
+    if not _valid_certificate_url(cert_url):
+        raise VerificationError("Certificate URL verification failed")
+    cert_data = urlopen(cert_url).read()
+    cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert_data)
+    if not _valid_certificate(cert):
+        raise VerificationError("Certificate verification failed")
+    return cert
+
+
+def verify_signature(cert, signature, signed_data):
+    try:
+        signature = base64.b64decode(signature)
+        crypto.verify(cert, signature, signed_data, 'sha1')
+    except crypto.Error as e:
+        raise VerificationError(e)
+
+
+def verify_timestamp(timestamp):
+    dt = datetime.utcnow() - timestamp.replace(tzinfo=None)
+    if dt.seconds > 150:
+        raise VerificationError("Timestamp verification failed")
+
+
+def verify_application_id(candidate, records):
+    if candidate not in records:
+        raise VerificationError("Application ID verification failed")
+
+
+def _valid_certificate_url(cert_url):
+    parsed_url = urlparse(cert_url)
+    if parsed_url.scheme == 'https':
+        if parsed_url.hostname == "s3.amazonaws.com":
+            if posixpath.normpath(parsed_url.path).startswith("/echo.api/"):
+                return True
+    return False
+
+
+def _valid_certificate(cert):
+    not_after = cert.get_notAfter().decode('utf-8')
+    not_after = datetime.strptime(not_after, '%Y%m%d%H%M%SZ')
+    if datetime.utcnow() >= not_after:
+        return False
+    found = False
+    for i in range(0, cert.get_extension_count()):
+        extension = cert.get_extension(i)
+        short_name = extension.get_short_name().decode('utf-8')
+        value = str(extension)
+        if 'subjectAltName' == short_name and 'DNS:echo-api.amazon.com' == value:
+            found = True
+            break
+    if not found:
+        return False
+    return True

--- a/wsgi.py
+++ b/wsgi.py
@@ -35,10 +35,14 @@ import re
 import string
 import sys
 import threading
+import ConfigParser
 
 # Load the kodi.py file from the same directory where this wsgi file is located
 sys.path += [os.path.dirname(__file__)]
 import kodi
+
+INI_FILE = os.path.join(os.path.dirname(__file__), "wsgi.ini")
+
 
 # This utility function constructs the required JSON for a full Alexa Skills Kit response
 
@@ -234,7 +238,7 @@ def alexa_big_step_backward(slots):
 # Shuffle all music by an artist
 def alexa_play_artist(slots):
   heard_artist = str(slots['Artist']['value']).lower().translate(None, string.punctuation)
-  
+
   print('Trying to play music by %s' % (heard_artist))
   sys.stdout.flush()
 
@@ -1183,6 +1187,13 @@ def on_intent(intent_request, session):
 
 # The main entry point for WSGI scripts
 def application(environ, start_response):
+  cfg = ConfigParser.SafeConfigParser()
+  cfg.read(INI_FILE)
+  os.environ['KODI_ADDRESS'] = cfg.get('kodi', 'address')
+  os.environ['KODI_PORT'] = cfg.get('kodi', 'port')
+  os.environ['KODI_USERNAME'] = cfg.get('kodi', 'username')
+  os.environ['KODI_PASSWORD'] = cfg.get('kodi', 'password')
+
   # Execute the handler that matches the URL
   for h in HANDLERS:
     if environ['PATH_INFO'] == h[0]:

--- a/wsgi.py
+++ b/wsgi.py
@@ -35,12 +35,17 @@ import re
 import string
 import sys
 import threading
-import aniso8601
 import ConfigParser
 
-# Load the kodi.py file from the same directory where this wsgi file is located
 sys.path += [os.path.dirname(__file__)]
-import verifier
+
+try:
+  import aniso8601
+  import verifier
+except:
+  # cert/appid verification dependencies are optional installs
+  pass
+
 import kodi
 
 INI_FILE = os.path.join(os.path.dirname(__file__), "wsgi.ini")
@@ -1124,8 +1129,7 @@ def do_alexa(environ, start_response):
         verifier.verify_application_id(alexa_msg['session']['application']['applicationId'], environ['KODI_APPID'])
     except verifier.VerificationError as e:
       print e.args[0]
-      start_response('502 No content', [])
-      return ['']
+      raise
 
     if alexa_request['type'] == 'LaunchRequest':
       # This is the type when you just say "Open <app>"


### PR DESCRIPTION
In reference to Issues #21 and #22.

Adds two environment variables for the WSGI handler:
- KODI_APPID
- KODI_VERIFY_CERT

If KODI_APPID is set and not empty, the skill will verify that the incoming request appid matches before processing the request.

If KODI_VERIFY_CERT==1, the skill will perform various checks on the certificate:
- Incoming request is from Amazon,
- Certificate URL is from Amazon,
- Timestamp of certificate is valid/not expired,
- Signature can be verified.

Additionally, this PR adds the ability to store all configuration in a file, 'wsgi.ini', which can look like:

```
[general]
app_id = amzn1.ask.skill.deadbeef-4e4f-ad61-fe42-aee7d2de083d
verify_cert = yes

[kodi]
address = 127.0.0.1
port = 8080
username = kodi
password = kodi
```

If we want to extend this to the Lambda handler, I'm happy to do that.  I just wasn't comfortable doing it since I don't know much about it and cannot test it.
