### PR TITLE
add a new env variable to define the SCHEME

### DIFF
--- a/.env.lambda
+++ b/.env.lambda
@@ -1,15 +1,29 @@
-SKILL_APPID =
-KODI_ADDRESS =
-KODI_PORT =
-KODI_USERNAME =
-KODI_PASSWORD =
-LAMBDA_ENV_VARS = KODI_PASSWORD,KODI_USERNAME,KODI_PORT,KODI_ADDRESS,SKILL_APPID
+
+KODI_ADDRESS = 
+KODI_PORT = 
+KODI_USERNAME = 
+KODI_PASSWORD = 
+
+# The Kodi webserver only supports HTTP. 
+# Uncomment KODI_SCHEME to tell the skill to use https between AWS and your local network
+# (only use if you have already set this up with your own certificates) 
+
+# KODI_SCHEME = https
+
+# If using a reverse proxy you might need to add an extra bit to the url before "jsonrpc"
+# You can do this with KODI_SUBPATH (don't use slashes before or after) 
+
+# KODI_SUBPATH = 
+
+SKILL_APPID = 
+
+LAMBDA_ENV_VARS = KODI_SCHEME,KODI_ADDRESS,KODI_PORT,KODI_SUBPATH,KODI_USERNAME,KODI_PASSWORD,SKILL_APPID
 
 AWS_DEFAULT_REGION = us-east-1
 LAMBDA_TIMEOUT = 60
 LAMBDA_MEMORY_SIZE = 128
 LAMBDA_HANDLER = wsgi.lambda_handler
 
-AWS_ACCESS_KEY_ID =
+AWS_ACCESS_KEY_ID = 
 AWS_SECRET_ACCESS_KEY =
-LAMBDA_ROLE =
+LAMBDA_ROLE = 

--- a/.env.wsgi
+++ b/.env.wsgi
@@ -1,6 +1,18 @@
 SKILL_APPID=
-SKILL_VERIFY_CERT=
+SKILL_VERIFY_CERT= 
+
 KODI_ADDRESS=
 KODI_PORT=
 KODI_USERNAME=
 KODI_PASSWORD=
+
+# The Kodi webserver only supports HTTP. 
+# Uncomment KODI_SCHEME to tell the skill to use https between AWS/Heroku and your local network
+# (only use if you have already set this up with your own certificates) 
+
+# KODI_SCHEME = https
+
+# If using a reverse proxy you might need to add an extra bit to the url before "jsonrpc"
+# You can do this with KODI_SUBPATH (don't use slashes before or after) 
+
+# KODI_SUBPATH = 

--- a/kodi.py
+++ b/kodi.py
@@ -77,17 +77,39 @@ def remove_the(name):
   else:
     return name
 
+# Remove extra slashes
+def http_normalize_slashes(url):
+    url = str(url)
+    segments = url.split('/')
+    correct_segments = []
+    for segment in segments:
+        if segment != '':
+            correct_segments.append(segment)
+    first_segment = str(correct_segments[0])
+    if first_segment.find('http') == -1:
+        correct_segments = ['http:'] + correct_segments
+    correct_segments[0] = correct_segments[0] + '/'
+    normalized_url = '/'.join(correct_segments)
+    return normalized_url
+
 # These two methods construct the JSON-RPC message and send it to the Kodi player
 def SendCommand(command):
-  # Change this to the IP address of your Kodi server or always pass in an address
+  # Do not use below for your own settings, use the .env file
   KODI = os.getenv('KODI_ADDRESS', '127.0.0.1')
   PORT = int(os.getenv('KODI_PORT', 8080))
   USER = os.getenv('KODI_USERNAME', 'kodi')
   PASS = os.getenv('KODI_PASSWORD', 'kodi')
 
-  print "Sending request to %s:%d" % (KODI, PORT)
+  SCHEME = os.getenv('KODI_SCHEME', 'http')     
+  SUBPATH = os.getenv('KODI_SUBPATH', '')
 
-  url = "http://%s:%d/jsonrpc" % (KODI, PORT)
+  # Join the environment variables into a url
+  url = "%s://%s:%d/%s/%s" % (SCHEME, KODI, PORT, SUBPATH, 'jsonrpc')
+
+  # Remove any double slashes in the url
+  url = http_normalize_slashes(url)
+
+  print "Sending request to %s" % (url)
 
   try:
     r = requests.post(url, data=command, auth=(USER, PASS))


### PR DESCRIPTION
I am not sure how this affects Heroku, there is a default to HTTP which should prevent any breakages due to the KODI_SCHEME env variable not being set.

Would the only Heroku change be the setting of the env var by adding it to the `config:set` command i.e. 

`heroku config:set KODI_SCHEME='https' KODI_ADDRESS='your_ip_or_dynamic_address' KODI_PORT='kodi_port' KODI_USERNAME='kodi_username' KODI_PASSWORD='kodi_password' --app app-name-and-number`.

If that is the case I will change the readme to include it.
