### PR TITLE
int definition for PORT changed to string

### DIFF
--- a/kodi.py
+++ b/kodi.py
@@ -85,13 +85,13 @@ def SetupEnvVars():
 def SendCommand(command):
   # Change this to the IP address of your Kodi server or always pass in an address
   KODI = os.getenv('KODI_ADDRESS', '127.0.0.1')
-  PORT = int(os.getenv('KODI_PORT', 8080))
+  PORT = os.getenv('KODI_PORT', '8080')
   USER = os.getenv('KODI_USERNAME', 'kodi')
   PASS = os.getenv('KODI_PASSWORD', 'kodi')
 
   print KODI
   
-  url = "http://%s:%d/jsonrpc" % (KODI, PORT)
+  url = "http://%s:%s/jsonrpc" % (KODI, PORT)
   try:
     r = requests.post(url, data=command, auth=(USER, PASS))
   except:


### PR DESCRIPTION
This allows the use of reverse proxy rules to be based on a subfolder in the url

e.g. `http://dyndns.domainname.com:33133/dosomethingiftheaddresshasthissubfolder`

Resulting in the full jsonrpc concatenated url:

`http://dyndns.domainname.com:33133/dosomethingiftheaddresshasthissubfolder/jsonrpc/request?=`

I am making these small tweaks to accompany a little guide I am putting together about how to set up a secure connection to a reverse proxy that only accepts traffic from a specific group of Amazon IPs.

I don't want to get people messing in the code to make these tweaks themselves, and with the change in the PR you can set the subfolder in the KODI_PORT var 

e.g. `KODI_PORT = 33133/dosomethingiftheaddresshasthissubfolder`
