### PR TITLE
Add the capability to resume movies and TV-Shows

### DIFF
--- a/kodi.py
+++ b/kodi.py
@@ -192,6 +192,12 @@ def PrepMoviePlaylist(movie_id):
 def StartVideoPlaylist():
   return SendCommand(RPCString("Player.Open", {"item": {"playlistid": 1}}))
 
+def PlayEpisode(ep_id, resume=True):
+  return SendCommand(RPCString("Player.Open", {"item": {"episodeid": ep_id}, "options": {"resume": resume}}))
+
+def PlayMovie(movie_id, resume=True):
+  return SendCommand(RPCString("Player.Open", {"item": {"movieid": movie_id}, "options": {"resume": resume}}))
+
 def AddSongsToPlaylist(song_ids):
   songs_array = []
 
@@ -462,13 +468,17 @@ def GetNewestEpisodeFromShow(show_id):
     return None
 
 def GetNextUnwatchedEpisode(show_id):
-  data = SendCommand(RPCString("VideoLibrary.GetEpisodes", {"limits":{"end":1},"tvshowid": int(show_id), "filter":{"field":"lastplayed", "operator":"greaterthan", "value":"0"}, "properties":["season", "episode", "lastplayed", "firstaired"], "sort":{"method":"lastplayed", "order":"descending"}}))
+  data = SendCommand(RPCString("VideoLibrary.GetEpisodes", {"limits":{"end":1},"tvshowid": int(show_id), "filter":{"field":"lastplayed", "operator":"greaterthan", "value":"0"}, "properties":["season", "episode", "lastplayed", "firstaired", "resume"], "sort":{"method":"lastplayed", "order":"descending"}}))
   if 'episodes' in data['result']:
     episode = data['result']['episodes'][0]
     episode_season = episode['season']
     episode_number = episode['episode']
 
-    next_episode = GetSpecificEpisode(show_id, episode_season, int(episode_number) + 1)
+    resume = episode['resume']['position']
+    if resume > 0:
+      next_episode = episode['episodeid']
+    else:
+      next_episode = GetSpecificEpisode(show_id, episode_season, int(episode_number) + 1)
 
     if next_episode:
       return next_episode

--- a/wsgi.py
+++ b/wsgi.py
@@ -897,9 +897,7 @@ def alexa_play_random_movie(slots):
     movies_array = movies['result']['movies']
     random_movie = random.choice(movies_array)
 
-    kodi.ClearVideoPlaylist()
-    kodi.PrepMoviePlaylist(random_movie['movieid'])
-    kodi.StartVideoPlaylist()
+    kodi.PlayMovie(random_movie['movieid'], False)
 
     return build_alexa_response('Playing %s' % (random_movie['label']), card_title)
   else:
@@ -919,9 +917,7 @@ def alexa_play_movie(slots):
     located = kodi.matchHeard(heard_movie, movies_array)
 
     if located:
-      kodi.ClearVideoPlaylist()
-      kodi.PrepMoviePlaylist(located['movieid'])
-      kodi.StartVideoPlaylist()
+      kodi.PlayMovie(located['movieid'])
 
       return build_alexa_response('Playing %s' % (heard_movie), card_title)
     else:
@@ -957,9 +953,7 @@ def alexa_play_random_episode(slots):
       episode_id = random.choice(episodes_array)
       episode_details = kodi.GetEpisodeDetails(episode_id)['result']['episodedetails']
 
-      kodi.ClearVideoPlaylist()
-      kodi.PrepEpisodePlayList(episode_id)
-      kodi.StartVideoPlaylist()
+      kodi.PlayEpisode(episode_id, False)
 
       return build_alexa_response('Playing season %d episode %d of %s' % (episode_details['season'], episode_details['episode'], heard_show), card_title)
     else:
@@ -988,9 +982,7 @@ def alexa_play_episode(slots):
       episode_result = kodi.GetSpecificEpisode(located['tvshowid'], heard_season, heard_episode)
 
       if episode_result:
-        kodi.ClearVideoPlaylist()
-        kodi.PrepEpisodePlayList(episode_result)
-        kodi.StartVideoPlaylist()
+        kodi.PlayEpisode(episode_result, False)
 
         return build_alexa_response('Playing season %s episode %s of %s' % (heard_season, heard_episode, heard_show), card_title)
 
@@ -1021,9 +1013,7 @@ def alexa_play_next_episode(slots):
       if next_episode:
         episode_details = kodi.GetEpisodeDetails(next_episode)['result']['episodedetails']
 
-        kodi.ClearVideoPlaylist()
-        kodi.PrepEpisodePlayList(next_episode)
-        kodi.StartVideoPlaylist()
+        kodi.PlayEpisode(next_episode)
 
         return build_alexa_response('Playing season %d episode %d of %s' % (episode_details['season'], episode_details['episode'], heard_show), card_title)
       else:
@@ -1053,9 +1043,7 @@ def alexa_play_newest_episode(slots):
       if episode:
         episode_details = kodi.GetEpisodeDetails(episode)['result']['episodedetails']
 
-        kodi.ClearVideoPlaylist()
-        kodi.PrepEpisodePlayList(episode)
-        kodi.StartVideoPlaylist()
+        kodi.PlayEpisode(episode)
 
         return build_alexa_response('Playing season %d episode %d of %s' % (episode_details['season'], episode_details['episode'], heard_show), card_title)
       else:
@@ -1080,9 +1068,7 @@ def alexa_continue_show(slots):
     if next_episode:
       episode_details = kodi.GetEpisodeDetails(next_episode)['result']['episodedetails']
 
-      kodi.ClearVideoPlaylist()
-      kodi.PrepEpisodePlayList(next_episode)
-      kodi.StartVideoPlaylist()
+      kodi.PlayEpisode(episode)
 
       return build_alexa_response('Playing season %d episode %d of %s' % (episode_details['season'], episode_details['episode'], last_show_obj['result']['episodes'][0]['showtitle']), card_title)
     else:


### PR DESCRIPTION
I'm often in the situation where I stop an episode or a movie in the middle. This usually happens when I start an episode over lunch and don't have time to finish it.

Thing is, there is currently no possibility to ask kodi to just keep going wherever I last stopped.

This commit allows just that. If the user asks to play a movie, kodi will resume if it was started earlier. If the user asks to play the next episode of a given show, kodi will either resume the last episode if it was not entirely watched, or play the next episode if available (i.e. what happens today).

Exceptions:
- random movies and episodes
- asking to play a specific episode from a TV show

Let me know how that sounds :-)

I also took the liberty to remove the functions used to manage the video playlist since they were not used anymore.
