### PR TITLE
Changes to WhatNewShows intent

### DIFF
--- a/alexa.intents
+++ b/alexa.intents
@@ -1,10 +1,6 @@
 {
   "intents": [
     {
-      "intent": "CheckNewShows",
-      "slots": []
-    },
-    {
       "intent": "WhatNewMovies",
       "slots": []
     },

--- a/alexa.utterances
+++ b/alexa.utterances
@@ -12,198 +12,6 @@ AudioStreamPrevious previous audio stream
 AudioStreamPrevious previous language
 Back go back
 Back navigate
-CheckNewShows are there any new shows
-CheckNewShows are there any new shows recorded
-CheckNewShows are there any new shows recorded to watch
-CheckNewShows are there any new shows recorded to watch today
-CheckNewShows are there any new shows recorded to watch tonight
-CheckNewShows are there any new shows recorded today
-CheckNewShows are there any new shows recorded tonight
-CheckNewShows are there any new shows to watch
-CheckNewShows are there any new shows to watch today
-CheckNewShows are there any new shows to watch tonight
-CheckNewShows are there any new shows today
-CheckNewShows are there any new shows tonight
-CheckNewShows are there new shows
-CheckNewShows are there new shows recorded
-CheckNewShows are there new shows recorded to watch
-CheckNewShows are there new shows recorded to watch today
-CheckNewShows are there new shows recorded to watch tonight
-CheckNewShows are there new shows recorded today
-CheckNewShows are there new shows recorded tonight
-CheckNewShows are there new shows to watch
-CheckNewShows are there new shows to watch today
-CheckNewShows are there new shows to watch tonight
-CheckNewShows are there new shows today
-CheckNewShows are there new shows tonight
-CheckNewShows are there some new shows
-CheckNewShows are there some new shows recorded
-CheckNewShows are there some new shows recorded to watch
-CheckNewShows are there some new shows recorded to watch today
-CheckNewShows are there some new shows recorded to watch tonight
-CheckNewShows are there some new shows recorded today
-CheckNewShows are there some new shows recorded tonight
-CheckNewShows are there some new shows to watch
-CheckNewShows are there some new shows to watch today
-CheckNewShows are there some new shows to watch tonight
-CheckNewShows are there some new shows today
-CheckNewShows are there some new shows tonight
-CheckNewShows do i have a new show
-CheckNewShows do i have a new show recorded
-CheckNewShows do i have a new show recorded to watch
-CheckNewShows do i have a new show recorded to watch today
-CheckNewShows do i have a new show recorded to watch tonight
-CheckNewShows do i have a new show recorded today
-CheckNewShows do i have a new show recorded tonight
-CheckNewShows do i have a new show to watch
-CheckNewShows do i have a new show to watch today
-CheckNewShows do i have a new show to watch tonight
-CheckNewShows do i have a new show today
-CheckNewShows do i have a new show tonight
-CheckNewShows do i have any new shows
-CheckNewShows do i have any new shows recorded
-CheckNewShows do i have any new shows recorded to watch
-CheckNewShows do i have any new shows recorded to watch today
-CheckNewShows do i have any new shows recorded to watch tonight
-CheckNewShows do i have any new shows recorded today
-CheckNewShows do i have any new shows recorded tonight
-CheckNewShows do i have any new shows to watch
-CheckNewShows do i have any new shows to watch today
-CheckNewShows do i have any new shows to watch tonight
-CheckNewShows do i have any new shows today
-CheckNewShows do i have any new shows tonight
-CheckNewShows do i have new shows
-CheckNewShows do i have new shows recorded
-CheckNewShows do i have new shows recorded to watch
-CheckNewShows do i have new shows recorded to watch today
-CheckNewShows do i have new shows recorded to watch tonight
-CheckNewShows do i have new shows recorded today
-CheckNewShows do i have new shows recorded tonight
-CheckNewShows do i have new shows to watch
-CheckNewShows do i have new shows to watch today
-CheckNewShows do i have new shows to watch tonight
-CheckNewShows do i have new shows today
-CheckNewShows do i have new shows tonight
-CheckNewShows do i have some new shows
-CheckNewShows do i have some new shows recorded
-CheckNewShows do i have some new shows recorded to watch
-CheckNewShows do i have some new shows recorded to watch today
-CheckNewShows do i have some new shows recorded to watch tonight
-CheckNewShows do i have some new shows recorded today
-CheckNewShows do i have some new shows recorded tonight
-CheckNewShows do i have some new shows to watch
-CheckNewShows do i have some new shows to watch today
-CheckNewShows do i have some new shows to watch tonight
-CheckNewShows do i have some new shows today
-CheckNewShows do i have some new shows tonight
-CheckNewShows do we have a new show
-CheckNewShows do we have a new show recorded
-CheckNewShows do we have a new show recorded to watch
-CheckNewShows do we have a new show recorded to watch today
-CheckNewShows do we have a new show recorded to watch tonight
-CheckNewShows do we have a new show recorded today
-CheckNewShows do we have a new show recorded tonight
-CheckNewShows do we have a new show to watch
-CheckNewShows do we have a new show to watch today
-CheckNewShows do we have a new show to watch tonight
-CheckNewShows do we have a new show today
-CheckNewShows do we have a new show tonight
-CheckNewShows do we have any new shows
-CheckNewShows do we have any new shows recorded
-CheckNewShows do we have any new shows recorded to watch
-CheckNewShows do we have any new shows recorded to watch today
-CheckNewShows do we have any new shows recorded to watch tonight
-CheckNewShows do we have any new shows recorded today
-CheckNewShows do we have any new shows recorded tonight
-CheckNewShows do we have any new shows to watch
-CheckNewShows do we have any new shows to watch today
-CheckNewShows do we have any new shows to watch tonight
-CheckNewShows do we have any new shows today
-CheckNewShows do we have any new shows tonight
-CheckNewShows do we have new shows
-CheckNewShows do we have new shows recorded
-CheckNewShows do we have new shows recorded to watch
-CheckNewShows do we have new shows recorded to watch today
-CheckNewShows do we have new shows recorded to watch tonight
-CheckNewShows do we have new shows recorded today
-CheckNewShows do we have new shows recorded tonight
-CheckNewShows do we have new shows to watch
-CheckNewShows do we have new shows to watch today
-CheckNewShows do we have new shows to watch tonight
-CheckNewShows do we have new shows today
-CheckNewShows do we have new shows tonight
-CheckNewShows do we have some new shows
-CheckNewShows do we have some new shows recorded
-CheckNewShows do we have some new shows recorded to watch
-CheckNewShows do we have some new shows recorded to watch today
-CheckNewShows do we have some new shows recorded to watch tonight
-CheckNewShows do we have some new shows recorded today
-CheckNewShows do we have some new shows recorded tonight
-CheckNewShows do we have some new shows to watch
-CheckNewShows do we have some new shows to watch today
-CheckNewShows do we have some new shows to watch tonight
-CheckNewShows do we have some new shows today
-CheckNewShows do we have some new shows tonight
-CheckNewShows if there are any new shows
-CheckNewShows if there are any new shows recorded
-CheckNewShows if there are any new shows recorded to watch
-CheckNewShows if there are any new shows recorded to watch today
-CheckNewShows if there are any new shows recorded to watch tonight
-CheckNewShows if there are any new shows recorded today
-CheckNewShows if there are any new shows recorded tonight
-CheckNewShows if there are any new shows to watch
-CheckNewShows if there are any new shows to watch today
-CheckNewShows if there are any new shows to watch tonight
-CheckNewShows if there are any new shows today
-CheckNewShows if there are any new shows tonight
-CheckNewShows if there are new shows
-CheckNewShows if there are new shows recorded
-CheckNewShows if there are new shows recorded to watch
-CheckNewShows if there are new shows recorded to watch today
-CheckNewShows if there are new shows recorded to watch tonight
-CheckNewShows if there are new shows recorded today
-CheckNewShows if there are new shows recorded tonight
-CheckNewShows if there are new shows to watch
-CheckNewShows if there are new shows to watch today
-CheckNewShows if there are new shows to watch tonight
-CheckNewShows if there are new shows today
-CheckNewShows if there are new shows tonight
-CheckNewShows if there are some new shows
-CheckNewShows if there are some new shows recorded
-CheckNewShows if there are some new shows recorded to watch
-CheckNewShows if there are some new shows recorded to watch today
-CheckNewShows if there are some new shows recorded to watch tonight
-CheckNewShows if there are some new shows recorded today
-CheckNewShows if there are some new shows recorded tonight
-CheckNewShows if there are some new shows to watch
-CheckNewShows if there are some new shows to watch today
-CheckNewShows if there are some new shows to watch tonight
-CheckNewShows if there are some new shows today
-CheckNewShows if there are some new shows tonight
-CheckNewShows if there is a new show
-CheckNewShows if there is a new show recorded
-CheckNewShows if there is a new show recorded to watch
-CheckNewShows if there is a new show recorded to watch today
-CheckNewShows if there is a new show recorded to watch tonight
-CheckNewShows if there is a new show recorded today
-CheckNewShows if there is a new show recorded tonight
-CheckNewShows if there is a new show to watch
-CheckNewShows if there is a new show to watch today
-CheckNewShows if there is a new show to watch tonight
-CheckNewShows if there is a new show today
-CheckNewShows if there is a new show tonight
-CheckNewShows is there a new show
-CheckNewShows is there a new show recorded
-CheckNewShows is there a new show recorded to watch
-CheckNewShows is there a new show recorded to watch today
-CheckNewShows is there a new show recorded to watch tonight
-CheckNewShows is there a new show recorded today
-CheckNewShows is there a new show recorded tonight
-CheckNewShows is there a new show to watch
-CheckNewShows is there a new show to watch today
-CheckNewShows is there a new show to watch tonight
-CheckNewShows is there a new show today
-CheckNewShows is there a new show tonight
 CleanAudio clean audio library
 CleanAudio clean music library
 CleanVideo clean library
@@ -840,6 +648,198 @@ WhatNewMovies what movies do you have
 WhatNewMovies what movies i have
 WhatNewMovies what movies we have
 WhatNewMovies what movies you have
+WhatNewShows are there any new shows
+WhatNewShows are there any new shows recorded
+WhatNewShows are there any new shows recorded to watch
+WhatNewShows are there any new shows recorded to watch today
+WhatNewShows are there any new shows recorded to watch tonight
+WhatNewShows are there any new shows recorded today
+WhatNewShows are there any new shows recorded tonight
+WhatNewShows are there any new shows to watch
+WhatNewShows are there any new shows to watch today
+WhatNewShows are there any new shows to watch tonight
+WhatNewShows are there any new shows today
+WhatNewShows are there any new shows tonight
+WhatNewShows are there new shows
+WhatNewShows are there new shows recorded
+WhatNewShows are there new shows recorded to watch
+WhatNewShows are there new shows recorded to watch today
+WhatNewShows are there new shows recorded to watch tonight
+WhatNewShows are there new shows recorded today
+WhatNewShows are there new shows recorded tonight
+WhatNewShows are there new shows to watch
+WhatNewShows are there new shows to watch today
+WhatNewShows are there new shows to watch tonight
+WhatNewShows are there new shows today
+WhatNewShows are there new shows tonight
+WhatNewShows are there some new shows
+WhatNewShows are there some new shows recorded
+WhatNewShows are there some new shows recorded to watch
+WhatNewShows are there some new shows recorded to watch today
+WhatNewShows are there some new shows recorded to watch tonight
+WhatNewShows are there some new shows recorded today
+WhatNewShows are there some new shows recorded tonight
+WhatNewShows are there some new shows to watch
+WhatNewShows are there some new shows to watch today
+WhatNewShows are there some new shows to watch tonight
+WhatNewShows are there some new shows today
+WhatNewShows are there some new shows tonight
+WhatNewShows do i have a new show
+WhatNewShows do i have a new show recorded
+WhatNewShows do i have a new show recorded to watch
+WhatNewShows do i have a new show recorded to watch today
+WhatNewShows do i have a new show recorded to watch tonight
+WhatNewShows do i have a new show recorded today
+WhatNewShows do i have a new show recorded tonight
+WhatNewShows do i have a new show to watch
+WhatNewShows do i have a new show to watch today
+WhatNewShows do i have a new show to watch tonight
+WhatNewShows do i have a new show today
+WhatNewShows do i have a new show tonight
+WhatNewShows do i have any new shows
+WhatNewShows do i have any new shows recorded
+WhatNewShows do i have any new shows recorded to watch
+WhatNewShows do i have any new shows recorded to watch today
+WhatNewShows do i have any new shows recorded to watch tonight
+WhatNewShows do i have any new shows recorded today
+WhatNewShows do i have any new shows recorded tonight
+WhatNewShows do i have any new shows to watch
+WhatNewShows do i have any new shows to watch today
+WhatNewShows do i have any new shows to watch tonight
+WhatNewShows do i have any new shows today
+WhatNewShows do i have any new shows tonight
+WhatNewShows do i have new shows
+WhatNewShows do i have new shows recorded
+WhatNewShows do i have new shows recorded to watch
+WhatNewShows do i have new shows recorded to watch today
+WhatNewShows do i have new shows recorded to watch tonight
+WhatNewShows do i have new shows recorded today
+WhatNewShows do i have new shows recorded tonight
+WhatNewShows do i have new shows to watch
+WhatNewShows do i have new shows to watch today
+WhatNewShows do i have new shows to watch tonight
+WhatNewShows do i have new shows today
+WhatNewShows do i have new shows tonight
+WhatNewShows do i have some new shows
+WhatNewShows do i have some new shows recorded
+WhatNewShows do i have some new shows recorded to watch
+WhatNewShows do i have some new shows recorded to watch today
+WhatNewShows do i have some new shows recorded to watch tonight
+WhatNewShows do i have some new shows recorded today
+WhatNewShows do i have some new shows recorded tonight
+WhatNewShows do i have some new shows to watch
+WhatNewShows do i have some new shows to watch today
+WhatNewShows do i have some new shows to watch tonight
+WhatNewShows do i have some new shows today
+WhatNewShows do i have some new shows tonight
+WhatNewShows do we have a new show
+WhatNewShows do we have a new show recorded
+WhatNewShows do we have a new show recorded to watch
+WhatNewShows do we have a new show recorded to watch today
+WhatNewShows do we have a new show recorded to watch tonight
+WhatNewShows do we have a new show recorded today
+WhatNewShows do we have a new show recorded tonight
+WhatNewShows do we have a new show to watch
+WhatNewShows do we have a new show to watch today
+WhatNewShows do we have a new show to watch tonight
+WhatNewShows do we have a new show today
+WhatNewShows do we have a new show tonight
+WhatNewShows do we have any new shows
+WhatNewShows do we have any new shows recorded
+WhatNewShows do we have any new shows recorded to watch
+WhatNewShows do we have any new shows recorded to watch today
+WhatNewShows do we have any new shows recorded to watch tonight
+WhatNewShows do we have any new shows recorded today
+WhatNewShows do we have any new shows recorded tonight
+WhatNewShows do we have any new shows to watch
+WhatNewShows do we have any new shows to watch today
+WhatNewShows do we have any new shows to watch tonight
+WhatNewShows do we have any new shows today
+WhatNewShows do we have any new shows tonight
+WhatNewShows do we have new shows
+WhatNewShows do we have new shows recorded
+WhatNewShows do we have new shows recorded to watch
+WhatNewShows do we have new shows recorded to watch today
+WhatNewShows do we have new shows recorded to watch tonight
+WhatNewShows do we have new shows recorded today
+WhatNewShows do we have new shows recorded tonight
+WhatNewShows do we have new shows to watch
+WhatNewShows do we have new shows to watch today
+WhatNewShows do we have new shows to watch tonight
+WhatNewShows do we have new shows today
+WhatNewShows do we have new shows tonight
+WhatNewShows do we have some new shows
+WhatNewShows do we have some new shows recorded
+WhatNewShows do we have some new shows recorded to watch
+WhatNewShows do we have some new shows recorded to watch today
+WhatNewShows do we have some new shows recorded to watch tonight
+WhatNewShows do we have some new shows recorded today
+WhatNewShows do we have some new shows recorded tonight
+WhatNewShows do we have some new shows to watch
+WhatNewShows do we have some new shows to watch today
+WhatNewShows do we have some new shows to watch tonight
+WhatNewShows do we have some new shows today
+WhatNewShows do we have some new shows tonight
+WhatNewShows if there are any new shows
+WhatNewShows if there are any new shows recorded
+WhatNewShows if there are any new shows recorded to watch
+WhatNewShows if there are any new shows recorded to watch today
+WhatNewShows if there are any new shows recorded to watch tonight
+WhatNewShows if there are any new shows recorded today
+WhatNewShows if there are any new shows recorded tonight
+WhatNewShows if there are any new shows to watch
+WhatNewShows if there are any new shows to watch today
+WhatNewShows if there are any new shows to watch tonight
+WhatNewShows if there are any new shows today
+WhatNewShows if there are any new shows tonight
+WhatNewShows if there are new shows
+WhatNewShows if there are new shows recorded
+WhatNewShows if there are new shows recorded to watch
+WhatNewShows if there are new shows recorded to watch today
+WhatNewShows if there are new shows recorded to watch tonight
+WhatNewShows if there are new shows recorded today
+WhatNewShows if there are new shows recorded tonight
+WhatNewShows if there are new shows to watch
+WhatNewShows if there are new shows to watch today
+WhatNewShows if there are new shows to watch tonight
+WhatNewShows if there are new shows today
+WhatNewShows if there are new shows tonight
+WhatNewShows if there are some new shows
+WhatNewShows if there are some new shows recorded
+WhatNewShows if there are some new shows recorded to watch
+WhatNewShows if there are some new shows recorded to watch today
+WhatNewShows if there are some new shows recorded to watch tonight
+WhatNewShows if there are some new shows recorded today
+WhatNewShows if there are some new shows recorded tonight
+WhatNewShows if there are some new shows to watch
+WhatNewShows if there are some new shows to watch today
+WhatNewShows if there are some new shows to watch tonight
+WhatNewShows if there are some new shows today
+WhatNewShows if there are some new shows tonight
+WhatNewShows if there is a new show
+WhatNewShows if there is a new show recorded
+WhatNewShows if there is a new show recorded to watch
+WhatNewShows if there is a new show recorded to watch today
+WhatNewShows if there is a new show recorded to watch tonight
+WhatNewShows if there is a new show recorded today
+WhatNewShows if there is a new show recorded tonight
+WhatNewShows if there is a new show to watch
+WhatNewShows if there is a new show to watch today
+WhatNewShows if there is a new show to watch tonight
+WhatNewShows if there is a new show today
+WhatNewShows if there is a new show tonight
+WhatNewShows is there a new show
+WhatNewShows is there a new show recorded
+WhatNewShows is there a new show recorded to watch
+WhatNewShows is there a new show recorded to watch today
+WhatNewShows is there a new show recorded to watch tonight
+WhatNewShows is there a new show recorded today
+WhatNewShows is there a new show recorded tonight
+WhatNewShows is there a new show to watch
+WhatNewShows is there a new show to watch today
+WhatNewShows is there a new show to watch tonight
+WhatNewShows is there a new show today
+WhatNewShows is there a new show tonight
 WhatNewShows what new shows are on the media server
 WhatNewShows what new shows are on the server
 WhatNewShows what new shows are ready

--- a/utterances.txt
+++ b/utterances.txt
@@ -108,13 +108,12 @@ PlayMovie (play/watch) movie {Movie}
 
 ContinueShow continue (/watching) (/last) show
 
-CheckNewShows (if there are/are there/do (we/i) have) (/any/some) new shows (/recorded) (/to watch) (/today/tonight)
-CheckNewShows (if there is/is there/do (we/i) have) a new show (/recorded) (/to watch) (/today/tonight)
-
 WhatNewMovies (if there are/are there/do (we/i) have) (/any/some) new movies (/recorded) (/to watch) (/today/tonight)
 WhatNewMovies (if there is/is there/do (we/i) have) a new movie (/recorded) (/to watch) (/today/tonight)
 WhatNewMovies what (/new) movies ((/do) (we/i/you) have/are (ready/waiting/recorded/there/on the (/media) server))
 
+WhatNewShows (if there are/are there/do (we/i) have) (/any/some) new shows (/recorded) (/to watch) (/today/tonight)
+WhatNewShows (if there is/is there/do (we/i) have) a new show (/recorded) (/to watch) (/today/tonight)
 WhatNewShows what (/new) shows ((/do) (we/i/you) have/are (ready/waiting/recorded/there/on the (/media) server))
 
 NewShowInquiry if (there is/we have) a new (/episode of) {Show}

--- a/wsgi.py
+++ b/wsgi.py
@@ -117,23 +117,22 @@ def alexa_check_new_episodes(slots):
   new_episodes = kodi.GetUnwatchedEpisodes()
 
   # Find out how many EPISODES were recently added and get the names of the SHOWS
-  really_new_episodes = [x for x in new_episodes if x['dateadded'] >= datetime.datetime.today() - datetime.timedelta(5)]
-  really_new_show_names = list(set([sanitize_name(x['show']) for x in really_new_episodes]))
+  new_show_names = list(set([sanitize_name(x['show']) for x in new_episodes]))
 
-  if len(really_new_episodes) == 0:
+  if len(new_episodes) == 0:
     answer = "There isn't anything new to watch."
-  elif len(really_new_show_names) == 1:
+  elif len(new_show_names) == 1:
     # Only one new show, so provide the number of episodes also.
-    count = len(really_new_episodes)
+    count = len(new_episodes)
     if count == 1:
-      answer = "There is one new episide of %(show)s to watch." % {"show":really_new_show_names[0]}
+      answer = "There is one new episide of %(show)s to watch." % {"show":new_show_names[0]}
     else:
-      answer = "You have %(count)d new episides of %(show)s." % {'count':count, 'show':really_new_show_names[0]}
-  elif len(really_new_show_names) == 2:
-    random.shuffle(really_new_show_names)
-    answer = "There are new episodes of %(show1)s and %(show2)s." % {'show1':really_new_show_names[0], 'show2':really_new_show_names[1]}
-  elif len(really_new_show_names) > 2:
-    show_sample = random.sample(really_new_show_names, 2)
+      answer = "You have %(count)d new episides of %(show)s." % {'count':count, 'show':new_show_names[0]}
+  elif len(new_show_names) == 2:
+    random.shuffle(new_show_names)
+    answer = "There are new episodes of %(show1)s and %(show2)s." % {'show1':new_show_names[0], 'show2':new_show_names[1]}
+  elif len(new_show_names) > 2:
+    show_sample = random.sample(new_show_names, 2)
     answer = "You have %(show1)s, %(show2)s, and more waiting to be watched." % {'show1':show_sample[0], 'show2':show_sample[1]}
   return build_alexa_response(answer, card_title)
 
@@ -1221,9 +1220,8 @@ def alexa_what_new_episodes(slots):
   new_episodes = kodi.GetUnwatchedEpisodes()
 
   # Find out how many EPISODES were recently added and get the names of the SHOWS
-  really_new_episodes = [x for x in new_episodes if x['dateadded'] >= datetime.datetime.today() - datetime.timedelta(5)]
-  really_new_show_names = list(set([sanitize_name(x['show']) for x in really_new_episodes]))
-  num_shows = len(really_new_show_names)
+  new_show_names = list(set([sanitize_name(x['show']) for x in new_episodes]))
+  num_shows = len(new_show_names)
 
   if num_shows == 0:
     # There's been nothing added to Kodi recently
@@ -1233,34 +1231,34 @@ def alexa_what_new_episodes(slots):
     ]
     answer = random.choice(answers)
     answer += suggest_alternate_activity()
-  elif len(really_new_show_names) == 1:
+  elif len(new_show_names) == 1:
     # There's only one new show, so provide information about the number of episodes, too.
-    count = len(really_new_episodes)
+    count = len(new_episodes)
     if count == 1:
       answers = [
-        "There is a single new episode of %(show)s." % {'show':really_new_show_names[0]},
-        "There is one new episode of %(show)s." % {'show':really_new_show_names[0]},
+        "There is a single new episode of %(show)s." % {'show':new_show_names[0]},
+        "There is one new episode of %(show)s." % {'show':new_show_names[0]},
       ]
     elif count == 2:
       answers = [
-        "There are a couple new episodes of %(show)s" % {'show':really_new_show_names[0]},
-        "There are two new episodes of %(show)s" % {'show':really_new_show_names[0]},
+        "There are a couple new episodes of %(show)s" % {'show':new_show_names[0]},
+        "There are two new episodes of %(show)s" % {'show':new_show_names[0]},
       ]
     elif count >= 5:
       answers = [
-        "There are lots and lots of new episodes of %(show)s" % {'show':really_new_show_names[0]},
-        "There are %(count)d new episodes of %(show)s" % {"count":count, "show":really_new_show_names[0]},
+        "There are lots and lots of new episodes of %(show)s" % {'show':new_show_names[0]},
+        "There are %(count)d new episodes of %(show)s" % {"count":count, "show":new_show_names[0]},
       ]
     else:
       answers = [
-        "You have a few new episodes of %(show)s" % {'show':really_new_show_names[0]},
-        "There are %(count)d new episodes of %(show)s" % {"count":count, "show":really_new_show_names[0]},
+        "You have a few new episodes of %(show)s" % {'show':new_show_names[0]},
+        "There are %(count)d new episodes of %(show)s" % {"count":count, "show":new_show_names[0]},
       ]
     answer = random.choice(answers)
   else:
     # More than one new show has new episodes ready
-    random.shuffle(really_new_show_names)
-    limited_new_show_names = really_new_show_names[0:5]
+    random.shuffle(new_show_names)
+    limited_new_show_names = new_show_names[0:5]
     show_list = limited_new_show_names[0]
     for one_show in limited_new_show_names[1:-1]:
       show_list += ", " + one_show

--- a/wsgi.py
+++ b/wsgi.py
@@ -1260,10 +1260,14 @@ def alexa_what_new_episodes(slots):
   else:
     # More than one new show has new episodes ready
     random.shuffle(really_new_show_names)
-    show_list = really_new_show_names[0]
-    for one_show in really_new_show_names[1:-1]:
+    limited_new_show_names = really_new_show_names[0:5]
+    show_list = limited_new_show_names[0]
+    for one_show in limited_new_show_names[1:-1]:
       show_list += ", " + one_show
-    show_list += ", and " + really_new_show_names[-1]
+    if num_shows > 5:
+      show_list += ", " + limited_new_show_names[-1] + ", and more"
+    else:
+      show_list += ", and" + limited_new_show_names[-1]
     answer = "There are new episodes of %(show_list)s." % {"show_list":show_list}
   return build_alexa_response(answer, card_title)
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -106,37 +106,6 @@ def sanitize_name(media_name):
   return media_name
 
 
-# Handle the CheckNewShows intent
-
-def alexa_check_new_episodes(slots):
-  card_title = 'Looking for new shows to watch'
-  print card_title
-  sys.stdout.flush()
-
-  # Get the list of unwatched EPISODES from Kodi
-  new_episodes = kodi.GetUnwatchedEpisodes()
-
-  # Find out how many EPISODES were recently added and get the names of the SHOWS
-  new_show_names = list(set([sanitize_name(x['show']) for x in new_episodes]))
-
-  if len(new_episodes) == 0:
-    answer = "There isn't anything new to watch."
-  elif len(new_show_names) == 1:
-    # Only one new show, so provide the number of episodes also.
-    count = len(new_episodes)
-    if count == 1:
-      answer = "There is one new episide of %(show)s to watch." % {"show":new_show_names[0]}
-    else:
-      answer = "You have %(count)d new episides of %(show)s." % {'count':count, 'show':new_show_names[0]}
-  elif len(new_show_names) == 2:
-    random.shuffle(new_show_names)
-    answer = "There are new episodes of %(show1)s and %(show2)s." % {'show1':new_show_names[0], 'show2':new_show_names[1]}
-  elif len(new_show_names) > 2:
-    show_sample = random.sample(new_show_names, 2)
-    answer = "You have %(show1)s, %(show2)s, and more waiting to be watched." % {'show1':show_sample[0], 'show2':show_sample[1]}
-  return build_alexa_response(answer, card_title)
-
-
 # Handle the NewShowInquiry intent.
 
 def alexa_new_show_inquiry(slots):
@@ -165,7 +134,7 @@ def alexa_new_show_inquiry(slots):
         if num_of_unwatched == 1:
           return build_alexa_response("There is one unseen episode of %(real_show)s." % {'real_show': heard_show}, card_title)
         else:
-          return build_alexa_response("There are %(num)d episodes of  %(real_show)s." % {'real_show': heard_show, 'num': num_of_unwatched}, card_title)
+          return build_alexa_response("There are %(num)d unseen episodes of %(real_show)s." % {'real_show': heard_show, 'num': num_of_unwatched}, card_title)
 
       else:
         return build_alexa_response("There are no unseen episodes of %(real_show)s." % {'real_show': heard_show}, card_title)
@@ -1316,7 +1285,6 @@ def prepare_help_message():
 # This maps the Intent names to the functions that provide the corresponding Alexa response.
 
 INTENTS = [
-  ['CheckNewShows', alexa_check_new_episodes],
   ['NewShowInquiry', alexa_new_show_inquiry],
   ['CurrentPlayItemInquiry', alexa_current_playitem_inquiry],
   ['WhatNewMovies', alexa_what_new_movies],


### PR DESCRIPTION
Making this a PR because it changes some existing behaviors.

In accordance with the 5-movie-response limit of the WhatNewMovies intent, I've restricted WhatNewShows to the same.  I'm open to changing the default value, but did feel it needed a limit for those of us with very large libraries.  This goes hand-in-hand with the next change too..

..I've removed the dateadded constraint on the list of shows to consider.  Previously, it would only consider episodes added in the last 5 days.  This is reasonable perhaps if the user views shows on Kodi in manor similar to cable TV, but I suspect that's not often the case.  Given the sheer number of shows my family watches, we frequently won't get around to an episode for quite some time, but I still want Alexa to remind us of it.

Lastly, I've merged CheckNewShows intent into WhatNewShows.  They simply didn't seem dissimilar enough to have both.

All of these changes are broken out into separate commits to make it easy to back one out if desired.