### PR TITLE
Rename step commands

### DIFF
--- a/alexa.intents
+++ b/alexa.intents
@@ -38,19 +38,19 @@
       "slots": []
     },
     {
-      "intent": "StepForward",
+      "intent": "PlayerSeekSmallForward",
       "slots": []
     },
     {
-      "intent": "StepBackward",
+      "intent": "PlayerSeekSmallBackward",
       "slots": []
     },
     {
-      "intent": "BigStepForward",
+      "intent": "PlayerSeekBigForward",
       "slots": []
     },
     {
-      "intent": "BigStepBackward",
+      "intent": "PlayerSeekBigBackward",
       "slots": []
     },
     {

--- a/alexa.utterances
+++ b/alexa.utterances
@@ -12,50 +12,14 @@ AudioStreamPrevious previous audio stream
 AudioStreamPrevious previous language
 Back go back
 Back navigate
-BigStepBackward big back jump
-BigStepBackward big back step
-BigStepBackward big backward jump
-BigStepBackward big backward step
-BigStepBackward big jump back
-BigStepBackward big jump backward
-BigStepBackward big step back
-BigStepBackward big step backward
-BigStepBackward large back jump
-BigStepBackward large back step
-BigStepBackward large backward jump
-BigStepBackward large backward step
-BigStepBackward large jump back
-BigStepBackward large jump backward
-BigStepBackward large step back
-BigStepBackward large step backward
-BigStepBackward long back jump
-BigStepBackward long back step
-BigStepBackward long backward jump
-BigStepBackward long backward step
-BigStepBackward long jump back
-BigStepBackward long jump backward
-BigStepBackward long step back
-BigStepBackward long step backward
-BigStepForward big forward jump
-BigStepForward big forward step
-BigStepForward big jump forward
-BigStepForward big step forward
-BigStepForward large forward jump
-BigStepForward large forward step
-BigStepForward large jump forward
-BigStepForward large step forward
-BigStepForward long forward jump
-BigStepForward long forward step
-BigStepForward long jump forward
-BigStepForward long step forward
 CleanAudio clean audio library
 CleanAudio clean music library
 CleanVideo clean library
 CleanVideo clean video library
 ContinueShow continue last show
-ContinueShow continue show
 ContinueShow continue playing last show
 ContinueShow continue playing show
+ContinueShow continue show
 ContinueShow continue watching last show
 ContinueShow continue watching show
 CurrentPlayItemInquiry what audio is currently playing
@@ -189,6 +153,28 @@ CurrentPlayItemTimeRemaining what time does video end
 CurrentPlayItemTimeRemaining what time is this over
 CurrentPlayItemTimeRemaining what time this ends
 CurrentPlayItemTimeRemaining what time this is over
+CurrentPlayItemTimeRemaining what time will audio end
+CurrentPlayItemTimeRemaining what time will episode end
+CurrentPlayItemTimeRemaining what time will film end
+CurrentPlayItemTimeRemaining what time will movie end
+CurrentPlayItemTimeRemaining what time will my audio end
+CurrentPlayItemTimeRemaining what time will my episode end
+CurrentPlayItemTimeRemaining what time will my film end
+CurrentPlayItemTimeRemaining what time will my movie end
+CurrentPlayItemTimeRemaining what time will my show end
+CurrentPlayItemTimeRemaining what time will my song end
+CurrentPlayItemTimeRemaining what time will my video end
+CurrentPlayItemTimeRemaining what time will show end
+CurrentPlayItemTimeRemaining what time will song end
+CurrentPlayItemTimeRemaining what time will this audio end
+CurrentPlayItemTimeRemaining what time will this end
+CurrentPlayItemTimeRemaining what time will this episode end
+CurrentPlayItemTimeRemaining what time will this film end
+CurrentPlayItemTimeRemaining what time will this movie end
+CurrentPlayItemTimeRemaining what time will this show end
+CurrentPlayItemTimeRemaining what time will this song end
+CurrentPlayItemTimeRemaining what time will this video end
+CurrentPlayItemTimeRemaining what time will video end
 CurrentPlayItemTimeRemaining when does audio end
 CurrentPlayItemTimeRemaining when does episode end
 CurrentPlayItemTimeRemaining when does film end
@@ -390,6 +376,66 @@ PlayerRotateClockwise rotate
 PlayerRotateClockwise rotate clockwise
 PlayerRotateClockwise rotate ninety degrees
 PlayerRotateCounterClockwise rotate counter clockwise
+PlayerSeekBigBackward big back jump
+PlayerSeekBigBackward big back step
+PlayerSeekBigBackward big backward jump
+PlayerSeekBigBackward big backward step
+PlayerSeekBigBackward big jump back
+PlayerSeekBigBackward big jump backward
+PlayerSeekBigBackward big step back
+PlayerSeekBigBackward big step backward
+PlayerSeekBigBackward large back jump
+PlayerSeekBigBackward large back step
+PlayerSeekBigBackward large backward jump
+PlayerSeekBigBackward large backward step
+PlayerSeekBigBackward large jump back
+PlayerSeekBigBackward large jump backward
+PlayerSeekBigBackward large step back
+PlayerSeekBigBackward large step backward
+PlayerSeekBigBackward long back jump
+PlayerSeekBigBackward long back step
+PlayerSeekBigBackward long backward jump
+PlayerSeekBigBackward long backward step
+PlayerSeekBigBackward long jump back
+PlayerSeekBigBackward long jump backward
+PlayerSeekBigBackward long step back
+PlayerSeekBigBackward long step backward
+PlayerSeekBigForward big forward jump
+PlayerSeekBigForward big forward step
+PlayerSeekBigForward big jump forward
+PlayerSeekBigForward big step forward
+PlayerSeekBigForward large forward jump
+PlayerSeekBigForward large forward step
+PlayerSeekBigForward large jump forward
+PlayerSeekBigForward large step forward
+PlayerSeekBigForward long forward jump
+PlayerSeekBigForward long forward step
+PlayerSeekBigForward long jump forward
+PlayerSeekBigForward long step forward
+PlayerSeekSmallBackward back jump
+PlayerSeekSmallBackward back step
+PlayerSeekSmallBackward backward jump
+PlayerSeekSmallBackward backward step
+PlayerSeekSmallBackward jump back
+PlayerSeekSmallBackward jump backward
+PlayerSeekSmallBackward small back jump
+PlayerSeekSmallBackward small back step
+PlayerSeekSmallBackward small backward jump
+PlayerSeekSmallBackward small backward step
+PlayerSeekSmallBackward small jump back
+PlayerSeekSmallBackward small jump backward
+PlayerSeekSmallBackward small step back
+PlayerSeekSmallBackward small step backward
+PlayerSeekSmallBackward step back
+PlayerSeekSmallBackward step backward
+PlayerSeekSmallForward forward jump
+PlayerSeekSmallForward forward step
+PlayerSeekSmallForward jump forward
+PlayerSeekSmallForward small forward jump
+PlayerSeekSmallForward small forward step
+PlayerSeekSmallForward small jump forward
+PlayerSeekSmallForward small step forward
+PlayerSeekSmallForward step forward
 PlayerZoomHold give me a hard copy right there
 PlayerZoomHold give me a hard copy there
 PlayerZoomHold hold
@@ -541,30 +587,6 @@ Skip skip
 Skip skip song
 StartOver replay
 StartOver start over
-StepBackward back jump
-StepBackward back step
-StepBackward backward jump
-StepBackward backward step
-StepBackward jump back
-StepBackward jump backward
-StepBackward small back jump
-StepBackward small back step
-StepBackward small backward jump
-StepBackward small backward step
-StepBackward small jump back
-StepBackward small jump backward
-StepBackward small step back
-StepBackward small step backward
-StepBackward step back
-StepBackward step backward
-StepForward forward jump
-StepForward forward step
-StepForward jump forward
-StepForward small forward jump
-StepForward small forward step
-StepForward small jump forward
-StepForward small step forward
-StepForward step forward
 Stop cancel
 Stop shut up
 Stop stop

--- a/kodi.py
+++ b/kodi.py
@@ -460,25 +460,25 @@ def Stop():
     return SendCommand(RPCString("Player.Stop", {"playerid":playerid}))
 
 
-def StepForward():
+def PlayerSeekSmallForward():
   playerid = GetPlayerID()
   if playerid:
     return SendCommand(RPCString("Player.Seek", {"playerid":playerid, "value":"smallforward"}))
 
 
-def StepBackward():
+def PlayerSeekSmallBackward():
   playerid = GetPlayerID()
   if playerid:
     return SendCommand(RPCString("Player.Seek", {"playerid":playerid, "value":"smallbackward"}))
 
 
-def BigStepForward():
+def PlayerSeekBigForward():
   playerid = GetPlayerID()
   if playerid:
     return SendCommand(RPCString("Player.Seek", {"playerid":playerid, "value":"bigforward"}))
 
 
-def BigStepBackward():
+def PlayerSeekBigBackward():
   playerid = GetPlayerID()
   if playerid:
     return SendCommand(RPCString("Player.Seek", {"playerid":playerid, "value":"bigbackward"}))

--- a/utterances.txt
+++ b/utterances.txt
@@ -152,11 +152,11 @@ Suspend go to sleep
 
 EjectMedia eject (/media/disc/audio disc/bluray/bluray disc/cd/dvd)
 
-StepForward (/small) (step/jump) forward
-StepForward (/small) forward (step/jump)
-BigStepForward (large/big/long) (step/jump) forward
-BigStepForward (large/big/long) forward (step/jump)
-StepBackward (/small) (step/jump) (backward/back)
-StepBackward (/small) (backward/back) (step/jump)
-BigStepBackward (large/big/long) (step/jump) (backward/back)
-BigStepBackward (large/big/long) (backward/back) (step/jump)
+PlayerSeekSmallForward (/small) (step/jump) forward
+PlayerSeekSmallForward (/small) forward (step/jump)
+PlayerSeekBigForward (large/big/long) (step/jump) forward
+PlayerSeekBigForward (large/big/long) forward (step/jump)
+PlayerSeekSmallBackward (/small) (step/jump) (backward/back)
+PlayerSeekSmallBackward (/small) (backward/back) (step/jump)
+PlayerSeekBigBackward (large/big/long) (step/jump) (backward/back)
+PlayerSeekBigBackward (large/big/long) (backward/back) (step/jump)

--- a/wsgi.py
+++ b/wsgi.py
@@ -244,46 +244,46 @@ def alexa_stop(slots):
   return build_alexa_response(answer, card_title)
 
 
-# Handle the StepForward intent.
-def alexa_step_forward(slots):
+# Handle the PlayerSeekSmallForward intent.
+def alexa_player_seek_smallforward(slots):
   card_title = 'Stepping forward'
   print card_title
   sys.stdout.flush()
 
-  kodi.StepForward()
+  kodi.PlayerSeekSmallForward()
   answer = ""
   return build_alexa_response(answer, card_title)
 
 
-# Handle the StepBackward intent.
-def alexa_step_backward(slots):
+# Handle the PlayerSeekSmallBackward intent.
+def alexa_player_seek_smallbackward(slots):
   card_title = 'Stepping backward'
   print card_title
   sys.stdout.flush()
 
-  kodi.StepBackward()
+  kodi.PlayerSeekSmallBackward()
   answer = ""
   return build_alexa_response(answer, card_title)
 
 
-# Handle the BigStepForward intent.
-def alexa_big_step_forward(slots):
+# Handle the PlayerSeekBigForward intent.
+def alexa_player_seek_bigforward(slots):
   card_title = 'Big Step forward'
   print card_title
   sys.stdout.flush()
 
-  kodi.BigStepForward()
+  kodi.PlayerSeekBigForward()
   answer = ""
   return build_alexa_response(answer, card_title)
 
 
-# Handle the BigStepBackward intent.
-def alexa_big_step_backward(slots):
+# Handle the PlayerSeekBigBackward intent.
+def alexa_player_seek_bigforward(slots):
   card_title = 'Big Step backward'
   print card_title
   sys.stdout.flush()
 
-  kodi.BigStepBackward()
+  kodi.PlayerSeekBigBackward()
   answer = ""
   return build_alexa_response(answer, card_title)
 
@@ -1422,10 +1422,10 @@ INTENTS = [
   ['WhatNewMovies', alexa_what_new_movies],
   ['WhatNewShows', alexa_what_new_episodes],
   ['PlayPause', alexa_play_pause],
-  ['StepForward', alexa_step_forward],
-  ['BigStepForward', alexa_big_step_forward],
-  ['StepBackward', alexa_step_backward],
-  ['BigStepBackward', alexa_big_step_backward],
+  ['PlayerSeekSmallForward', alexa_player_seek_smallforward],
+  ['PlayerSeekBigForward', alexa_player_seek_bigforward],
+  ['PlayerSeekSmallBackward', alexa_player_seek_smallbackward],
+  ['PlayerSeekBigBackward', alexa_player_seek_bigforward],
   ['Stop', alexa_stop],
   ['WhatAlbums', alexa_what_albums],
   ['ListenToArtist', alexa_play_artist],


### PR DESCRIPTION
Changed "step" to "seek" and prepended them all with "Player" for better relationship with the Kodi methods.

Initially it was just keep them grouped in the utterances file when that is sorted alphabetically

The commands are still "step forward" for now until seek is working with numerical values (in development)