### PR TITLE
changes to EjectMedia utterances

### DIFF
--- a/alexa.utterances
+++ b/alexa.utterances
@@ -238,12 +238,21 @@ Down go down
 Down navigate down
 EjectMedia eject
 EjectMedia eject audio disc
-EjectMedia eject bluray
-EjectMedia eject bluray disc
-EjectMedia eject cd
+EjectMedia eject blu-ray
+EjectMedia eject blu-ray disc
+EjectMedia eject c. d.
+EjectMedia eject compact disc
+EjectMedia eject d. v. d.
 EjectMedia eject disc
-EjectMedia eject dvd
 EjectMedia eject media
+EjectMedia eject the audio disc
+EjectMedia eject the blu-ray
+EjectMedia eject the blu-ray disc
+EjectMedia eject the c. d.
+EjectMedia eject the compact disc
+EjectMedia eject the d. v. d.
+EjectMedia eject the disc
+EjectMedia eject the media
 Fullscreen fullscreen
 Fullscreen toggle fullscreen
 Fullscreen toggle visualizer

--- a/utterances.txt
+++ b/utterances.txt
@@ -174,7 +174,8 @@ Suspend (suspend/sleep) (/system)
 Suspend put system to sleep
 Suspend go to sleep
 
-EjectMedia eject (/media/disc/audio disc/bluray/bluray disc/cd/dvd)
+EjectMedia eject (/media/disc/compact disc/audio disc/blu-ray/blu-ray disc/c. d./d. v. d.)
+EjectMedia eject the (media/disc/compact disc/audio disc/blu-ray/blu-ray disc/c. d./d. v. d.)
 
 PlayerSeekSmallForward (/small) (step/jump) forward
 PlayerSeekSmallForward (/small) forward (step/jump)


### PR DESCRIPTION
added periods to cd dvd
included versions using "the" e.g. "eject the disc"