### PR TITLE
[backport] Fix BigForward/Backward and StartOver

### DIFF
--- a/kodi.py
+++ b/kodi.py
@@ -512,7 +512,7 @@ def PlayPrev():
 def PlayStartOver():
   playerid = GetPlayerID()
   if playerid is not None:
-    return SendCommand(RPCString("Player.GoTo", {"playerid":playerid, "to": "previous"}))
+    return SendCommand(RPCString("Player.Seek", {"playerid":playerid, "value": 0}))
 
 
 def Stop():

--- a/wsgi.py
+++ b/wsgi.py
@@ -303,7 +303,7 @@ def alexa_player_seek_bigforward(slots):
 
 
 # Handle the PlayerSeekBigBackward intent.
-def alexa_player_seek_bigforward(slots):
+def alexa_player_seek_bigbackward(slots):
   card_title = 'Big Step backward'
   print card_title
   sys.stdout.flush()
@@ -1820,7 +1820,7 @@ INTENTS = [
   ['PlayerSeekSmallForward', alexa_player_seek_smallforward],
   ['PlayerSeekBigForward', alexa_player_seek_bigforward],
   ['PlayerSeekSmallBackward', alexa_player_seek_smallbackward],
-  ['PlayerSeekBigBackward', alexa_player_seek_bigforward],
+  ['PlayerSeekBigBackward', alexa_player_seek_bigbackward],
   ['Home', alexa_go_home],
   ['Back', alexa_back],
   ['Up', alexa_up],


### PR DESCRIPTION
- Backport from PR #120 
- `alexa_player_seek_bigforward` is defined twice, the second one should
be `alexa_player_seek_bigbackward`
- Change `PlayStartOver` use of `Player.GoTo` to `Player.Seek`
  - `Player.GoTo` doesn't work for non-playlist entries