### PR TITLE
Remove pycountry

### DIFF
--- a/kodi.py
+++ b/kodi.py
@@ -36,7 +36,6 @@ import random
 import re
 import string
 import sys
-import pycountry
 from fuzzywuzzy import fuzz
 from fuzzywuzzy import process
 
@@ -943,7 +942,7 @@ def GetCurrentSubtitles():
   if curprops is not None:
     try:
       lang = curprops['currentsubtitle']['language']
-      subs = pycountry.languages.get(bibliographic=lang).name
+      subs = lang
       name = curprops['currentsubtitle']['name']
       if name:
         subs += " " + name
@@ -959,7 +958,7 @@ def GetCurrentAudioStream():
   if curprops is not None:
     try:
       lang = curprops['currentaudiostream']['language']
-      stream = pycountry.languages.get(bibliographic=lang).name
+      stream = lang
       name = curprops['currentaudiostream']['name']
       if name:
         stream += " " + name

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 requests
 gunicorn
 yaep
-pycountry
 pytz
 fuzzywuzzy


### PR DESCRIPTION
The large package size is causing the "Signature expired" error when deploying on a machine with a slow upload speed. As a quick fix I removed the pycountry requirement but I haven't added the lightweight fix used in my [flask-ask-remove-pycountry](https://github.com/digiltd/kodi-alexa/tree/flask-ask-remove-pycountry) branch. So for now it just reads the country code, not the country.