### PR TITLE
Sync streaming music with ListenTo*.

### DIFF
--- a/alexa.py
+++ b/alexa.py
@@ -42,7 +42,7 @@ CAN_STREAM = music.has_music_functionality()
 
 # Needs to be instanced after app is configured
 # ask = Ask(app, "/", None, TEMPLATE_FILE) # For when PR gets merged on Flask-Ask project
-ask = Ask(app, '/')
+ask = Ask(app, "/")
 
 
 # Start of intent methods
@@ -406,14 +406,23 @@ def alexa_stream_album(Album, Artist):
           album_located = kodi.matchHeard(heard_album, albums_list)
 
           if album_located:
-            album_result = album_located['albumid']
-# XXXXXXXXXXXX
-#            kodi.Stop()
-#            kodi.ClearAudioPlaylist()
-#            kodi.AddAlbumToPlaylist(album_result)
-#            kodi.StartAudioPlaylist()
-# XXXXXXXXXXXX
-            response_text = render_template('streaming_album_artist', album_name=heard_album, artist=heard_artist).encode("utf-8")
+            songs_result = kodi.GetAlbumSongsPath(album_located['albumid'])
+            songs = songs_result['result']['songs']
+
+            songs_array = []
+
+            for song in songs:
+              songs_array.append(kodi.PrepareDownload(song['file']))
+
+            if len(songs_array) > 0:
+              random.shuffle(songs_array)
+              playlist_queue = music.MusicPlayer(songs_array)
+
+              response_text = render_template('streaming_album_artist', album_name=heard_album, artist=heard_artist).encode("utf-8")
+              audio('').clear_queue(stop=True)
+              return audio(response_text).play(songs_array[0])
+            else:
+              response_text = render_template('could_not_find_album_artist', album_name=heard_album, artist=heard_artist).encode("utf-8")
           else:
             response_text = render_template('could_not_find_album_artist', album_name=heard_album, artist=heard_artist).encode("utf-8")
         else:
@@ -429,14 +438,23 @@ def alexa_stream_album(Album, Artist):
       album_located = kodi.matchHeard(heard_album, albums_list)
 
       if album_located:
-        album_result = album_located['albumid']
-# XXXXXXXXXXXX
-#        kodi.Stop()
-#        kodi.ClearAudioPlaylist()
-#        kodi.AddAlbumToPlaylist(album_result)
-#        kodi.StartAudioPlaylist()
-# XXXXXXXXXXXX
-        response_text = render_template('streaming_album', album_name=heard_album).encode("utf-8")
+        songs_result = kodi.GetAlbumSongsPath(album_located['albumid'])
+        songs = songs_result['result']['songs']
+
+        songs_array = []
+
+        for song in songs:
+          songs_array.append(kodi.PrepareDownload(song['file']))
+
+        if len(songs_array) > 0:
+          random.shuffle(songs_array)
+          playlist_queue = music.MusicPlayer(songs_array)
+
+          response_text = render_template('streaming_album', album_name=heard_album).encode("utf-8")
+          audio('').clear_queue(stop=True)
+          return audio(response_text).play(songs_array[0])
+        else:
+          response_text = render_template('could_not_find_album', album_name=heard_album).encode("utf-8")
       else:
         response_text = render_template('could_not_find_album', album_name=heard_album).encode("utf-8")
     else:
@@ -526,14 +544,26 @@ def alexa_stream_song(Song, Artist):
           song_located = kodi.matchHeard(heard_song, songs_list)
 
           if song_located:
-            song_result = song_located['songid']
-# XXXXXXXXXXXX
-#            kodi.Stop()
-#            kodi.ClearAudioPlaylist()
-#            kodi.AddSongToPlaylist(song_result)
-#            kodi.StartAudioPlaylist()
-# XXXXXXXXXXXX
-            response_text = render_template('streaming_song_artist', song_name=heard_song, artist=heard_artist).encode("utf-8")
+            songs_array = []
+            song = None
+
+            song_result = kodi.GetSongIdPath(song_located['songid'])
+
+            if 'songdetails' in song_result['result']:
+              song = song_result['result']['songdetails']['file']
+
+            if song:
+              songs_array.append(kodi.PrepareDownload(song))
+
+            if len(songs_array) > 0:
+              random.shuffle(songs_array)
+              playlist_queue = music.MusicPlayer(songs_array)
+
+              response_text = render_template('streaming_song_artist', song_name=heard_song, artist=heard_artist).encode("utf-8")
+              audio('').clear_queue(stop=True)
+              return audio(response_text).play(songs_array[0])
+            else:
+              response_text = render_template('could_not_find_song_artist', song_name=heard_song, artist=heard_artist).encode("utf-8")
           else:
             response_text = render_template('could_not_find_song_artist', song_name=heard_song, artist=heard_artist).encode("utf-8")
         else:
@@ -549,14 +579,26 @@ def alexa_stream_song(Song, Artist):
       song_located = kodi.matchHeard(heard_song, songs_list)
 
       if song_located:
-        song_result = song_located['songid']
-# XXXXXXXXXXXX
-#        kodi.Stop()
-#        kodi.ClearAudioPlaylist()
-#        kodi.AddSongToPlaylist(song_result)
-#        kodi.StartAudioPlaylist()
-# XXXXXXXXXXXX
-        response_text = render_template('streaming_song', song_name=heard_song).encode("utf-8")
+        songs_array = []
+        song = None
+
+        song_result = kodi.GetSongIdPath(song_located['songid'])
+
+        if 'songdetails' in song_result['result']:
+          song = song_result['result']['songdetails']['file']
+
+        if song:
+          songs_array.append(kodi.PrepareDownload(song))
+
+        if len(songs_array) > 0:
+          random.shuffle(songs_array)
+          playlist_queue = music.MusicPlayer(songs_array)
+
+          response_text = render_template('streaming_song', song_name=heard_song).encode("utf-8")
+          audio('').clear_queue(stop=True)
+          return audio(response_text).play(songs_array[0])
+        else:
+          response_text = render_template('could_not_find_song', song_name=heard_song).encode("utf-8")
       else:
         response_text = render_template('could_not_find_song', song_name=heard_song).encode("utf-8")
     else:
@@ -652,14 +694,23 @@ def alexa_stream_album_or_song(Song, Album, Artist):
         album_located = kodi.matchHeard(heard_search, albums_list)
 
         if album_located:
-          album_result = album_located['albumid']
-# XXXXXXXXXXXX
-#          kodi.Stop()
-#          kodi.ClearAudioPlaylist()
-#          kodi.AddAlbumToPlaylist(album_result)
-#          kodi.StartAudioPlaylist()
-# XXXXXXXXXXXX
-          response_text = render_template('streaming_album_artist', album_name=heard_search, artist=heard_artist).encode("utf-8")
+          songs_result = kodi.GetAlbumSongsPath(album_located['albumid'])
+          songs = songs_result['result']['songs']
+
+          songs_array = []
+
+          for song in songs:
+            songs_array.append(kodi.PrepareDownload(song['file']))
+
+          if len(songs_array) > 0:
+            random.shuffle(songs_array)
+            playlist_queue = music.MusicPlayer(songs_array)
+
+            response_text = render_template('streaming_album_artist', album_name=heard_search, artist=heard_artist).encode("utf-8")
+            audio('').clear_queue(stop=True)
+            return audio(response_text).play(songs_array[0])
+          else:
+            response_text = render_template('could_not_find_album_artist', album_name=heard_search, artist=heard_artist).encode("utf-8")
         else:
           songs = kodi.GetArtistSongs(located['artistid'])
           if 'result' in songs and 'songs' in songs['result']:
@@ -667,14 +718,26 @@ def alexa_stream_album_or_song(Song, Album, Artist):
             song_located = kodi.matchHeard(heard_search, songs_list)
 
             if song_located:
-              song_result = song_located['songid']
-# XXXXXXXXXXXX
-#              kodi.Stop()
-#              kodi.ClearAudioPlaylist()
-#              kodi.AddSongToPlaylist(song_result)
-#              kodi.StartAudioPlaylist()
-# XXXXXXXXXXXX
-              response_text = render_template('streaming_song_artist', song_name=heard_search, artist=heard_artist).encode("utf-8")
+              songs_array = []
+              song = None
+
+              song_result = kodi.GetSongIdPath(song_located['songid'])
+
+              if 'songdetails' in song_result['result']:
+                song = song_result['result']['songdetails']['file']
+
+              if song:
+                songs_array.append(kodi.PrepareDownload(song))
+
+              if len(songs_array) > 0:
+                random.shuffle(songs_array)
+                playlist_queue = music.MusicPlayer(songs_array)
+
+                response_text = render_template('streaming_song_artist', song_name=heard_search, artist=heard_artist).encode("utf-8")
+                audio('').clear_queue(stop=True)
+                return audio(response_text).play(songs_array[0])
+              else:
+                response_text = render_template('could_not_find_song_artist', song_name=heard_search, artist=heard_artist).encode("utf-8")
             else:
               response_text = render_template('could_not_find_song_artist', heard_name=heard_search, artist=heard_artist).encode("utf-8")
           else:
@@ -725,22 +788,22 @@ def alexa_stream_recently_added_songs():
   response_text = render_template('no_recent_songs').encode("utf-8")
   print card_title
 
-  songs_result = kodi.GetRecentlyAddedSongs()
+  songs_result = kodi.GetRecentlyAddedSongsPath()
   if songs_result:
     songs = songs_result['result']['songs']
 
     songs_array = []
 
     for song in songs:
-      songs_array.append(song['songid'])
+      songs_array.append(kodi.PrepareDownload(song['file']))
 
-# XXXXXXXXXXXX
-#    kodi.Stop()
-#    kodi.ClearAudioPlaylist()
-#    kodi.AddSongsToPlaylist(songs_array, True)
-#    kodi.StartAudioPlaylist()
-# XXXXXXXXXXXX
-    response_text = ""
+    if len(songs_array) > 0:
+      random.shuffle(songs_array)
+      playlist_queue = music.MusicPlayer(songs_array)
+
+      response_text = render_template('streaming_recent_songs').encode("utf-8")
+      audio('').clear_queue(stop=True)
+      return audio(response_text).play(songs_array[0])
 
   return statement(response_text).simple_card(card_title, response_text)
 

--- a/alexa.py
+++ b/alexa.py
@@ -467,7 +467,7 @@ def alexa_stream_album(Album, Artist):
 @ask.intent('ListenToSong')
 def alexa_listen_song(Song, Artist):
   heard_song = str(Song).lower().translate(None, string.punctuation)
-  card_title = render_template('playing_song').encode("utf-8")
+  card_title = render_template('playing_song_card').encode("utf-8")
   print card_title
 
   if Artist:
@@ -527,7 +527,7 @@ def alexa_stream_song(Song, Artist):
     return statement(response_text)
 
   heard_song = str(Song).lower().translate(None, string.punctuation)
-  card_title = render_template('streaming_song').encode("utf-8")
+  card_title = render_template('streaming_song_card').encode("utf-8")
   print card_title
 
   if Artist:

--- a/alexa.py
+++ b/alexa.py
@@ -870,24 +870,23 @@ def alexa_stream_audio_playlist(AudioPlaylist, shuffle=False):
 
   playlist = kodi.FindAudioPlaylist(heard_search)
   if playlist:
-    if shuffle:
-      songs = kodi.GetPlaylistItems(playlist)['result']['files']
+    songs = kodi.GetPlaylistItems(playlist)['result']['files']
 
-      songs_array = []
+    songs_array = []
 
-      for song in songs:
-        songs_array.append(song['id'])
+    for song in songs:
+      songs_array.append(kodi.PrepareDownload(song['file']))
 
-# XXXXXXXXXXXX
-#      kodi.Stop()
-#      kodi.ClearAudioPlaylist()
-#      kodi.AddSongsToPlaylist(songs_array, True)
-#      kodi.StartAudioPlaylist()
-#    else:
-#      kodi.Stop()
-#      kodi.StartAudioPlaylist(playlist)
-# XXXXXXXXXXXX
-    response_text = render_template('playing_playlist', action=op, playlist_name=heard_search).encode("utf-8")
+    if len(songs_array) > 0:
+      if shuffle:
+        random.shuffle(songs_array)
+      playlist_queue = music.MusicPlayer(songs_array)
+
+      response_text = render_template('playing_playlist', action=op, playlist_name=heard_search).encode("utf-8")
+      audio('').clear_queue(stop=True)
+      return audio(response_text).play(songs_array[0])
+    else:
+      response_text = render_template('could_not_find_playlist', heard_name=heard_search).encode("utf-8")
   else:
     response_text = render_template('could_not_find_playlist', heard_name=heard_search).encode("utf-8")
 

--- a/generate_custom_slots.py
+++ b/generate_custom_slots.py
@@ -23,7 +23,7 @@ if 'result' in retrieved and 'artists' in retrieved['result']:
 cleaned = list(set(all))
 cleaned = filter(None, cleaned)
 random.shuffle(cleaned)
-cleaned = cleaned[:2500]
+cleaned = cleaned[:400]
 
 gfile = open('MUSICARTISTS', 'w')
 for a in cleaned:
@@ -46,7 +46,7 @@ if 'result' in retrieved and 'albums' in retrieved['result']:
 cleaned = list(set(all))
 cleaned = filter(None, cleaned)
 random.shuffle(cleaned)
-cleaned = cleaned[:2500]
+cleaned = cleaned[:400]
 
 gfile = open('MUSICALBUMS', 'w')
 for a in cleaned:
@@ -69,7 +69,7 @@ if 'result' in retrieved and 'songs' in retrieved['result']:
 cleaned = list(set(all))
 cleaned = filter(None, cleaned)
 random.shuffle(cleaned)
-cleaned = cleaned[:2500]
+cleaned = cleaned[:400]
 
 gfile = open('MUSICSONGS', 'w')
 for a in cleaned:
@@ -92,7 +92,7 @@ if 'result' in retrieved and 'files' in retrieved['result']:
 cleaned = list(set(all))
 cleaned = filter(None, cleaned)
 random.shuffle(cleaned)
-cleaned = cleaned[:2500]
+cleaned = cleaned[:400]
 
 gfile = open('MUSICPLAYLISTS', 'w')
 for a in cleaned:
@@ -115,7 +115,7 @@ if 'result' in retrieved and 'files' in retrieved['result']:
 cleaned = list(set(all))
 cleaned = filter(None, cleaned)
 random.shuffle(cleaned)
-cleaned = cleaned[:2500]
+cleaned = cleaned[:400]
 
 gfile = open('VIDEOPLAYLISTS', 'w')
 for a in cleaned:
@@ -138,7 +138,7 @@ if 'result' in retrieved and 'genres' in retrieved['result']:
 cleaned = list(set(all))
 cleaned = filter(None, cleaned)
 random.shuffle(cleaned)
-cleaned = cleaned[:2500]
+cleaned = cleaned[:400]
 
 gfile = open('MOVIEGENRES', 'w')
 for a in cleaned:
@@ -161,7 +161,7 @@ if 'result' in retrieved and 'movies' in retrieved['result']:
 cleaned = list(set(all))
 cleaned = filter(None, cleaned)
 random.shuffle(cleaned)
-cleaned = cleaned[:2500]
+cleaned = cleaned[:400]
 
 gfile = open('MOVIES', 'w')
 for a in cleaned:
@@ -184,7 +184,7 @@ if 'result' in retrieved and 'tvshows' in retrieved['result']:
 cleaned = list(set(all))
 cleaned = filter(None, cleaned)
 random.shuffle(cleaned)
-cleaned = cleaned[:2500]
+cleaned = cleaned[:400]
 
 gfile = open('SHOWS', 'w')
 for a in cleaned:
@@ -208,7 +208,7 @@ for content in ['video', 'audio', 'image', 'executable']:
 cleaned = list(set(all))
 cleaned = filter(None, cleaned)
 random.shuffle(cleaned)
-cleaned = cleaned[:2500]
+cleaned = cleaned[:400]
 
 gfile = open('ADDONS', 'w')
 for a in cleaned:

--- a/kodi.py
+++ b/kodi.py
@@ -706,6 +706,10 @@ def GetArtistSongsPath(artist_id):
   return SendCommand(RPCString("AudioLibrary.GetSongs", {"filter": {"artistid": int(artist_id)}, "properties":["file"]}))
 
 
+def GetAlbumSongsPath(album_id):
+  return SendCommand(RPCString("AudioLibrary.GetSongs", {"filter": {"albumid": int(album_id)}, "properties":["file"]}))
+
+
 def GetSongs():
   return SendCommand(RPCString("AudioLibrary.GetSongs"))
 
@@ -714,12 +718,20 @@ def GetSongsPath():
   return SendCommand(RPCString("AudioLibrary.GetSongs", {"properties":["file"]}))
 
 
+def GetSongIdPath(song_id):
+  return SendCommand(RPCString("AudioLibrary.GetSongDetails", {"songid": int(song_id), "properties":["file"]}))
+
+
 def GetRecentlyAddedAlbums():
   return SendCommand(RPCString("AudioLibrary.GetRecentlyAddedAlbums", {'properties':['artist']}))
 
 
 def GetRecentlyAddedSongs():
   return SendCommand(RPCString("AudioLibrary.GetRecentlyAddedSongs", {'properties':['artist']}))
+
+
+def GetRecentlyAddedSongsPath():
+  return SendCommand(RPCString("AudioLibrary.GetRecentlyAddedSongs", {'properties':['artist', 'file']}))
 
 
 def GetVideoPlaylists():

--- a/music.py
+++ b/music.py
@@ -22,7 +22,9 @@ class MusicPlayer:
     from pymongo import MongoClient
     self.mongo_uri = os.getenv('MONGODB_URI')
     self.client = MongoClient(self.mongo_uri)
-    self.db = self.client[os.getenv('MONGODB_NAME')]
+
+    database_name = self.mongo_uri.rsplit('/', 1)[1] 
+    self.db = self.client[database_name]
     self.playlists = self.db['playlist-info']
 
     if len(urls) > 0:

--- a/music.py
+++ b/music.py
@@ -23,7 +23,7 @@ class MusicPlayer:
     self.mongo_uri = os.getenv('MONGODB_URI')
     self.client = MongoClient(self.mongo_uri)
 
-    database_name = self.mongo_uri.rsplit('/', 1)[1] 
+    database_name = self.mongo_uri.rsplit('/', 1)[1]
     self.db = self.client[database_name]
     self.playlists = self.db['playlist-info']
 

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -113,7 +113,33 @@
       ]
     },
     {
+      "intent": "StreamAlbum",
+      "slots": [
+        {
+          "name": "Artist",
+          "type": "MUSICARTISTS"
+        },
+        {
+          "name": "Album",
+          "type": "MUSICALBUMS"
+        }
+      ]
+    },
+    {
       "intent": "ListenToSong",
+      "slots": [
+        {
+          "name": "Artist",
+          "type": "MUSICARTISTS"
+        },
+        {
+          "name": "Song",
+          "type": "MUSICSONGS"
+        }
+      ]
+    },
+    {
+      "intent": "StreamSong",
       "slots": [
         {
           "name": "Artist",
@@ -143,7 +169,33 @@
       ]
     },
     {
+      "intent": "StreamAlbumOrSong",
+      "slots": [
+        {
+          "name": "Artist",
+          "type": "MUSICARTISTS"
+        },
+        {
+          "name": "Album",
+          "type": "MUSICALBUMS"
+        },
+        {
+          "name": "Song",
+          "type": "MUSICSONGS"
+        }
+      ]
+    },
+    {
       "intent": "ListenToAudioPlaylist",
+      "slots": [
+        {
+          "name": "AudioPlaylist",
+          "type": "MUSICPLAYLISTS"
+        }
+      ]
+    },
+    {
+      "intent": "StreamAudioPlaylist",
       "slots": [
         {
           "name": "AudioPlaylist",
@@ -162,6 +214,9 @@
     },
     {
       "intent": "ListenToAudioPlaylistRecent"
+    },
+    {
+      "intent": "StreamAudioPlaylistRecent"
     },
     {
       "intent": "WatchEpisode",

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -152,6 +152,9 @@
       ]
     },
     {
+      "intent": "StreamThis"
+    },
+    {
       "intent": "ListenToAlbumOrSong",
       "slots": [
         {

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -1118,6 +1118,10 @@ StartOver von vorne
 StartOver wiederhol
 StartOver wiederhole
 StartOver wiederholen
+StreamAlbum stream album {Album}
+StreamAlbum stream album {Album} by {Artist}
+StreamAlbumOrSong stream {Album} by {Artist}
+StreamAlbumOrSong stream {Song} by {Artist}
 StreamArtist Stream Lieder von dem Artist {Artist}
 StreamArtist Stream Lieder von dem Komponist {Artist}
 StreamArtist Stream Lieder von dem Künstler {Artist}
@@ -1154,6 +1158,22 @@ StreamArtist Stream Songs von der Gruppe {Artist}
 StreamArtist Stream Songs von der Komponistin {Artist}
 StreamArtist Stream Songs von der Künstlerin {Artist}
 StreamArtist Stream Songs von {Artist}
+StreamAudioPlaylist stream audio playlist {AudioPlaylist}
+StreamAudioPlaylist stream music playlist {AudioPlaylist}
+StreamAudioPlaylist stream playlist {AudioPlaylist}
+StreamAudioPlaylist stream song playlist {AudioPlaylist}
+StreamAudioPlaylist stream {AudioPlaylist} audio playlist
+StreamAudioPlaylist stream {AudioPlaylist} music playlist
+StreamAudioPlaylist stream {AudioPlaylist} playlist
+StreamAudioPlaylist stream {AudioPlaylist} song playlist
+StreamAudioPlaylistRecent stream recent albums
+StreamAudioPlaylistRecent stream recent audio
+StreamAudioPlaylistRecent stream recent music
+StreamAudioPlaylistRecent stream recent songs
+StreamAudioPlaylistRecent stream recently added albums
+StreamAudioPlaylistRecent stream recently added audio
+StreamAudioPlaylistRecent stream recently added music
+StreamAudioPlaylistRecent stream recently added songs
 StreamPartyMode stream Lieder
 StreamPartyMode stream Mucke
 StreamPartyMode stream Musik
@@ -1166,6 +1186,8 @@ StreamPartyMode stream zufällige Lieder
 StreamPartyMode stream zufällige Mucke
 StreamPartyMode stream zufällige Musik
 StreamPartyMode stream zufällige Songs
+StreamSong stream song {Song}
+StreamSong stream song {Song} by {Artist}
 SubtitlesNext Untertitel umschalten
 SubtitlesNext nächster Untertitel
 SubtitlesOff Untertitel aus

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -1188,6 +1188,8 @@ StreamPartyMode stream zufällige Musik
 StreamPartyMode stream zufällige Songs
 StreamSong stream song {Song}
 StreamSong stream song {Song} by {Artist}
+StreamThis stream Aktuelle playlist
+StreamThis stream this
 SubtitlesNext Untertitel umschalten
 SubtitlesNext nächster Untertitel
 SubtitlesOff Untertitel aus

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -564,11 +564,33 @@ Skip skip
 Skip skip song
 StartOver replay
 StartOver start over
+StreamAlbum stream album {Album}
+StreamAlbum stream album {Album} by {Artist}
+StreamAlbumOrSong stream {Album} by {Artist}
+StreamAlbumOrSong stream {Song} by {Artist}
 StreamArtist stream artist {Artist}
 StreamArtist stream music by {Artist}
+StreamAudioPlaylist stream audio playlist {AudioPlaylist}
+StreamAudioPlaylist stream music playlist {AudioPlaylist}
+StreamAudioPlaylist stream playlist {AudioPlaylist}
+StreamAudioPlaylist stream song playlist {AudioPlaylist}
+StreamAudioPlaylist stream {AudioPlaylist} audio playlist
+StreamAudioPlaylist stream {AudioPlaylist} music playlist
+StreamAudioPlaylist stream {AudioPlaylist} playlist
+StreamAudioPlaylist stream {AudioPlaylist} song playlist
+StreamAudioPlaylistRecent stream recent albums
+StreamAudioPlaylistRecent stream recent audio
+StreamAudioPlaylistRecent stream recent music
+StreamAudioPlaylistRecent stream recent songs
+StreamAudioPlaylistRecent stream recently added albums
+StreamAudioPlaylistRecent stream recently added audio
+StreamAudioPlaylistRecent stream recently added music
+StreamAudioPlaylistRecent stream recently added songs
 StreamPartyMode stream all music
 StreamPartyMode stream music
 StreamPartyMode stream random music
+StreamSong stream song {Song}
+StreamSong stream song {Song} by {Artist}
 SubtitlesNext next subtitle language
 SubtitlesNext next subtitles
 SubtitlesNext switch subtitle language

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -591,6 +591,8 @@ StreamPartyMode stream music
 StreamPartyMode stream random music
 StreamSong stream song {Song}
 StreamSong stream song {Song} by {Artist}
+StreamThis stream current playlist
+StreamThis stream this
 SubtitlesNext next subtitle language
 SubtitlesNext next subtitles
 SubtitlesNext switch subtitle language

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -10,13 +10,13 @@ could_not_find_generic: "Konnte diese Formulierung nicht finden"
 
 could_not_find_album: "Konnte das Album {{ album_name }} nicht finden"
 
-could_not_find_album_artist: "Konnte das Album, {{ album_name }} von {{ artist }} nicht finden"
+could_not_find_album_artist: "Konnte das Album {{ album_name }} von {{ artist }} nicht finden"
 
 could_not_find_song: "Konnte den song {{ song_name }} nicht finden"
 
-could_not_find_song_artist: "Konnte den Song, {{ song_name }} von {{ artist }}"
+could_not_find_song_artist: "Konnte den Song {{ song_name }} von {{ artist }}"
 
-could_not_find_multi: "Konnte, {{ heard_name }} von {{ artist }} nicht finden"
+could_not_find_multi: "Konnte {{ heard_name }} von {{ artist }} nicht finden"
 
 could_not_find_playlist: "Ich konnte die Playlist {{ heard_name }} nicht finden"
 
@@ -34,19 +34,31 @@ opening: "Öffne {{ heard_name }}"
 
 playing: "Spiele {{ heard_name }}"
 
+streaming: "Streaming {{ heard_name }}"
+
 playing_album: "Spiele das Album {{ album_name }}"
 
-playing_album_artist: "Spiele das Album, {{ album_name }} von {{ artist }}"
+streaming_album: "Streaming album {{ album_name }}"
+
+playing_album_artist: "Spiele das Album {{ album_name }} von {{ artist }}"
+
+streaming_album_artist: "Streaming album {{ album_name }} by {{ artist }}"
 
 playing_song: "Speile den Song {{ song_name }}"
 
-playing_song_artist: "Spiele den Song, {{ song_name }} von {{ artist }}"
+streaming_song: "Streaming song {{ song_name }}"
+
+playing_song_artist: "Spiele den Song {{ song_name }} von {{ artist }}"
+
+streaming_song_artist: "Streaming song {{ song_name }} by {{ artist }}"
 
 playing_playlist: "{{ action }} Playlist {{ playlist_name }}"
 
 playing_party: "Starte party play"
 
-playing_genre: "Siele den {{ genre }} Film, {{ movie_name }}"
+streaming_party: "Streaming party mode"
+
+playing_genre: "Siele den {{ genre }} Film {{ movie_name }}"
 
 playing_action: "{{ action }} {{ movie_name }}"
 
@@ -56,11 +68,9 @@ playing_episode_number: "Spiele die Staffel {{ season }} Folge {{ episode }} von
 
 playing_action_episode_number: "{{ action }} Staffel {{ season }} Folge {{ episode }} von {{ show_name }}"
 
-streaming: "Streaming {{ heard_name }}"
-
-streaming_party: "Streaming party mode"
-
 playing_empty: "Spiele"
+
+streaming_empty: "Streaming"
 
 resuming_empty: "Setze fort"
 
@@ -102,7 +112,7 @@ you_have_episode_list: "Es gibt neue Folgen für {{ list }}"
 
 volume_set: "Lautstärke auf {{ num }} gestellt"
 
-cant_steam: "Du must Datenbank Informationen zu deinen Umgebungs Variablen hinzufügen damit dies funktioniert"
+cant_stream: "Du must Datenbank Informationen zu deinen Umgebungs Variablen hinzufügen damit dies funktioniert"
 
 open_remote: "Starte Ferbedienungs Modus, zum benutzen sage gehe nach oben, gehe zurück als wenn Du die Ferbedienung beutzen würdest, Sage Stop um den Kontroll Modus zu verlassen"
 
@@ -235,6 +245,8 @@ playing_same: "Starte aktuellen Titel erneut"
 
 playing_recent_songs: "Spiele kürzlich hinzugefügte Songs"
 
+streaming_recent_songs: "Streaming recently added songs"
+
 playing_random_movie: "Spiele zufälligen Film"
 
 playing_random_movie_genre: "Spiele zufälligen {{ genre }} Film"
@@ -251,9 +263,15 @@ playing_newest_episode: "Spiele die neuste Folge von {{ heard_show }}"
 
 playing_album_card: "Spiele Album"
 
+streaming_album_card: "Streaming album"
+
 playing_song: "Spiele Song"
 
+streaming_song: "Streaming song"
+
 playing_album_or_song: "Spile Album oder Song"
+
+streaming_album_or_song: "Streaming album or song"
 
 action_audio_playlist: "{{ action }} Audio Playlist"
 

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -265,9 +265,9 @@ playing_album_card: "Spiele Album"
 
 streaming_album_card: "Streaming album"
 
-playing_song: "Spiele Song"
+playing_song_card: "Spiele Song"
 
-streaming_song: "Streaming song"
+streaming_song_card: "Streaming song"
 
 playing_album_or_song: "Spile Album oder Song"
 

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -122,6 +122,10 @@ what_to_do: "Was möchtest Du tun?"
 
 welcome: "Willkommen zum Kodi skill."
 
+nothing_currently_playing: "Kodi isn't playing any music right now."
+
+transferring_stream: "Transferring stream from Kodi to Alexa."
+
 
 ############################
 ##  Card Title Templates  ##
@@ -290,6 +294,8 @@ help_card: "Hilfe"
 open_remote_card: "Öffne Fernbedienung"
 
 playback_stopped: "Wiedergabe Stoppen"
+
+streaming_current_playlist: "Streaming current playlist"
 
 
 ############################

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -10,13 +10,13 @@ could_not_find_generic: "Could not find that phrase"
 
 could_not_find_album: "Could not find album {{ album_name }}"
 
-could_not_find_album_artist: "Could not find album, {{ album_name }} by {{ artist }}"
+could_not_find_album_artist: "Could not find album {{ album_name }} by {{ artist }}"
 
 could_not_find_song: "Could not find song {{ song_name }}"
 
-could_not_find_song_artist: "Could not find song, {{ song_name }} by {{ artist }}"
+could_not_find_song_artist: "Could not find song {{ song_name }} by {{ artist }}"
 
-could_not_find_multi: "Could not find, {{ heard_name }} by {{ artist }}"
+could_not_find_multi: "Could not find {{ heard_name }} by {{ artist }}"
 
 could_not_find_playlist: "I could not find a playlist named {{ heard_name }}"
 
@@ -34,19 +34,31 @@ opening: "Opening {{ heard_name }}"
 
 playing: "Playing {{ heard_name }}"
 
+streaming: "Streaming {{ heard_name }}"
+
 playing_album: "Playing album {{ album_name }}"
 
-playing_album_artist: "Playing album, {{ album_name }} by {{ artist }}"
+streaming_album: "Streaming album {{ album_name }}"
+
+playing_album_artist: "Playing album {{ album_name }} by {{ artist }}"
+
+streaming_album_artist: "Streaming album {{ album_name }} by {{ artist }}"
 
 playing_song: "Playing song {{ song_name }}"
 
-playing_song_artist: "Playing song, {{ song_name }} by {{ artist }}"
+streaming_song: "Streaming song {{ song_name }}"
+
+playing_song_artist: "Playing song {{ song_name }} by {{ artist }}"
+
+streaming_song_artist: "Streaming song {{ song_name }} by {{ artist }}"
 
 playing_playlist: "{{ action }} playlist {{ playlist_name }}"
 
 playing_party: "Starting party play"
 
-playing_genre: "Playing the {{ genre }} movie, {{ movie_name }}"
+streaming_party: "Streaming party mode"
+
+playing_genre: "Playing the {{ genre }} movie {{ movie_name }}"
 
 playing_action: "{{ action }} {{ movie_name }}"
 
@@ -56,11 +68,9 @@ playing_episode_number: "Playing season {{ season }} episode {{ episode }} of {{
 
 playing_action_episode_number: "{{ action }} season {{ season }} episode {{ episode }} of {{ show_name }}"
 
-streaming: "Streaming {{ heard_name }}"
-
-streaming_party: "Streaming party mode"
-
 playing_empty: "Playing"
+
+streaming_empty: "Streaming"
 
 resuming_empty: "Resuming"
 
@@ -102,7 +112,7 @@ you_have_episode_list: "There are new episodes of {{ list }}"
 
 volume_set: "Volume set to {{ num }}"
 
-cant_steam: "You need to add database information to your environment variables for this to work"
+cant_stream: "You need to add database information to your environment variables for this to work"
 
 open_remote: "Starting remote control mode, to use say go up, go back as if you were pressing buttons, say stop to exit control mode"
 
@@ -235,6 +245,8 @@ playing_same: "Starting current item over"
 
 playing_recent_songs: "Playing recently added songs"
 
+streaming_recent_songs: "Streaming recently added songs"
+
 playing_random_movie: "Playing a random movie"
 
 playing_random_movie_genre: "Playing a random {{ genre }} movie"
@@ -251,9 +263,15 @@ playing_newest_episode: "Playing the newest episode of {{ heard_show }}"
 
 playing_album_card: "Playing album"
 
+streaming_album_card: "Streaming album"
+
 playing_song: "Playing song"
 
+streaming_song: "Streaming song"
+
 playing_album_or_song: "Playing album or song"
+
+streaming_album_or_song: "Streaming album or song"
 
 action_audio_playlist: "{{ action }} audio playlist"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -122,6 +122,10 @@ what_to_do: "What would you like to do?"
 
 welcome: "Welcome to the Kodi skill."
 
+nothing_currently_playing: "Kodi isn't playing any music right now."
+
+transferring_stream: "Transferring stream from Kodi to Alexa."
+
 
 ############################
 ##  Card Title Templates  ##
@@ -290,6 +294,8 @@ help_card: "Help"
 open_remote_card: "Opening remote"
 
 playback_stopped: "Playback stopped"
+
+streaming_current_playlist: "Streaming current playlist"
 
 
 ############################

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -265,9 +265,9 @@ playing_album_card: "Playing album"
 
 streaming_album_card: "Streaming album"
 
-playing_song: "Playing song"
+playing_song_card: "Playing song"
 
-streaming_song: "Streaming song"
+streaming_song_card: "Streaming song"
 
 playing_album_or_song: "Playing album or song"
 

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -88,17 +88,32 @@ StreamArtist Stream (Musik/Lieder/Songs/Mucke) von (/dem Artist/der Artistin/dem
 
 ListenToAlbum spiel(/e) (das Album/die CD/die Platte) {Album} (/von {Artist})
 
+StreamAlbum stream album {Album}
+StreamAlbum stream album {Album} by {Artist}
+
 ListenToSong spiel(/e) (das Lied/den Song) {Song}
 ListenToSong spiel(/e) (das Lied/den Song) {Song} von {Artist}
+
+StreamSong stream song {Song}
+StreamSong stream song {Song} by {Artist}
 
 ListenToAlbumOrSong spiel(/e) (/das Album/die CD/die Platte) {Album} von (/der Band/der Gruppe) {Artist}
 ListenToAlbumOrSong spiel(/e) (/das Lied/den Song) {Song} von {Artist}
 
+StreamAlbumOrSong stream {Album} by {Artist}
+StreamAlbumOrSong stream {Song} by {Artist}
+
 ListenToAudioPlaylist spiel(/e) (Musik/Lieder/Song) playlist {AudioPlaylist}
 ListenToAudioPlaylist spiel(/e) {AudioPlaylist} (Musik/Lieder/Song) playlist
 
+StreamAudioPlaylist stream (song/music/audio/) playlist {AudioPlaylist}
+StreamAudioPlaylist stream {AudioPlaylist} (song/music/audio/) playlist
+
 ListenToAudioPlaylistRecent spiel(/e) neue (Musik/Lieder/Songs)
 ListenToAudioPlaylistRecent spiel(/e) (zuletzt/kürzlich) hinzugefügte (Musik/Lieder/Songs)
+
+StreamAudioPlaylistRecent stream recent (songs/music/audio/albums)
+StreamAudioPlaylistRecent stream recently added (songs/music/audio/albums)
 
 WatchRandomMovie zeige (/zufälligen) (/{Genre}) Film
 

--- a/utterances.txt
+++ b/utterances.txt
@@ -90,19 +90,34 @@ StreamArtist stream (music by/artist) {Artist}
 ListenToAlbum (play/listen to) album {Album}
 ListenToAlbum (play/listen to) album {Album} by {Artist}
 
+StreamAlbum stream album {Album}
+StreamAlbum stream album {Album} by {Artist}
+
 ListenToSong (play/listen to) song {Song}
 ListenToSong (play/listen to) song {Song} by {Artist}
 
+StreamSong stream song {Song}
+StreamSong stream song {Song} by {Artist}
+
 ListenToAlbumOrSong (play/listen to) {Album} by {Artist}
 ListenToAlbumOrSong (play/listen to) {Song} by {Artist}
+
+StreamAlbumOrSong stream {Album} by {Artist}
+StreamAlbumOrSong stream {Song} by {Artist}
 
 ListenToAudioPlaylist (play/listen to) (song/music/audio) playlist {AudioPlaylist}
 ListenToAudioPlaylist (play/listen to) {AudioPlaylist} (song/music/audio) playlist
 ListenToAudioPlaylist listen to playlist {AudioPlaylist}
 ListenToAudioPlaylist listen to {AudioPlaylist} playlist
 
+StreamAudioPlaylist stream (song/music/audio/) playlist {AudioPlaylist}
+StreamAudioPlaylist stream {AudioPlaylist} (song/music/audio/) playlist
+
 ListenToAudioPlaylistRecent (play/listen to/shuffle) recent (songs/music/audio/albums)
 ListenToAudioPlaylistRecent (play/listen to/shuffle) recently added (songs/music/audio/albums)
+
+StreamAudioPlaylistRecent stream recent (songs/music/audio/albums)
+StreamAudioPlaylistRecent stream recently added (songs/music/audio/albums)
 
 WatchRandomMovie (play/watch) random (/{Genre}) (movie/film)
 

--- a/utterances.txt
+++ b/utterances.txt
@@ -119,6 +119,8 @@ ListenToAudioPlaylistRecent (play/listen to/shuffle) recently added (songs/music
 StreamAudioPlaylistRecent stream recent (songs/music/audio/albums)
 StreamAudioPlaylistRecent stream recently added (songs/music/audio/albums)
 
+StreamThis stream (this/current playlist)
+
 WatchRandomMovie (play/watch) random (/{Genre}) (movie/film)
 
 WatchMovie (play/watch) (movie/film) {Movie}


### PR DESCRIPTION
This is basically a copy/paste of the existing music methods for streaming.  Ideally, we'll want to factor out the common code, but in the interest of getting 2.5 out the door, we decided to take this route for now.

One 'gotcha' is that I'm having trouble coming up with verbage to allow shuffling playlists by default.  "Alexa, shuffle/play playlist" makes enough sense, but when the main verb here is "stream," I'm not sure how to fire that off.  My suggestion would be to implement AMAZON.Shuffle* (and AMAZON.Loop*) and just make, "Alexa, ask Kodi to stream playlist foo," play it in order by default.  I'll make Issues for these if we decide to go that route.

This is the first(?) PR that affects our translations.  I think the precedent is to insert your own language strings into the other files, which is what I've done.

This does mean that at least as of this PR, a few of the responses and utterances are in English for German deployments as well.  They will remain in English until a kind German-speaking individual can replace them :)

Further, because of the numerous new references to the music slots, I had to reduce the slot generator limit to 400 per slot to get the skill to save.  @m0ngr31 has already taken care of this on the web slot generator.

Finally, we will need to update documentation to warn users that they should re-generate their slot values so they don't encounter the above issue upon upgrading.