### PR TITLE
Deep search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,20 @@ SKILL_TZ=
 # Uncomment the following if you'd like "Alexa, tell Kodi to shut down" to
 # quit Kodi instead of shutting down the system.
 # SHUTDOWN_MEANS_QUIT=1
+
+# Uncomment the following to disable deeper searches on generic play commands.
+# By default, if you ask to play media without specifying the type, the skill
+# will search through the entire library to find a match.
+#
+# For example, if you ask, "Alexa, ask Kodi to play ninety nine red balloons,"
+# the skill will search library items in the following order to find the song:
+#
+#   Movies -> Shows -> Artists -> Songs -> Albums
+#
+# If your library is really large, this can take some time to complete.  While
+# it will eventually execute, Alexa may report that the skill timed out.  If
+# this behavior bothers you, you can disable deep searches.
+#
+# When disabled, Alexa will simply provide help in the response directing you
+# to issue a play command that includes the media type of the item.
+#DISABLE_DEEP_SEARCH=1

--- a/alexa.py
+++ b/alexa.py
@@ -475,14 +475,18 @@ def alexa_play_media(Movie=None, Artist=None, content=None):
   card_title = 'Playing "%s"' % (heard_search)
   print card_title
 
-  if (len(heard_search) > 0):
-    response_text = find_and_play(heard_search, content, heard_slot)
-    if not response_text and heard_slot != 'unknown':
-      response_text = find_and_play(heard_search, content, slot_ignore=heard_slot)
-    if not response_text:
-      response_text = render_template('could_not_find', heard_name=heard_search).encode("utf-8")
+  disable_ds = os.getenv('DISABLE_DEEP_SEARCH')
+  if disable_ds and disable_ds != 'None':
+    response_text = render_template('help_play').encode("utf-8")
   else:
-    response_text = render_template('error_parsing_results').encode("utf-8")
+    if (len(heard_search) > 0):
+      response_text = find_and_play(heard_search, content, heard_slot)
+      if not response_text and heard_slot != 'unknown':
+        response_text = find_and_play(heard_search, content, slot_ignore=heard_slot)
+      if not response_text:
+        response_text = render_template('could_not_find', heard_name=heard_search).encode("utf-8")
+    else:
+      response_text = render_template('error_parsing_results').encode("utf-8")
 
   return statement(response_text).simple_card(card_title, response_text)
 

--- a/app.json
+++ b/app.json
@@ -51,6 +51,11 @@
       "description": "If you'd like 'Alexa, tell Kodi to shut down' to quit Kodi instead of shutting down the system.",
       "value": "",
       "required": false
+    },
+    "DISABLE_DEEP_SEARCH": {
+      "description": "If you'd like to disable searching the entire library with generic play commands.",
+      "value": "",
+      "required": false
     }
   },
   "image": "heroku/python"

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -109,7 +109,25 @@
       "intent": "AMAZON.HelpIntent"
     },
     {
+      "intent": "PlayMedia",
+      "slots": [
+        {
+          "name": "Movie",
+          "type": "MOVIES"
+        }
+      ]
+    },
+    {
       "intent": "WhatAlbums",
+      "slots": [
+        {
+          "name": "Artist",
+          "type": "MUSICARTISTS"
+        }
+      ]
+    },
+    {
+      "intent": "ListenToAudio",
       "slots": [
         {
           "name": "Artist",
@@ -189,6 +207,15 @@
     },
     {
       "intent": "ListenToAudioPlaylistRecent"
+    },
+    {
+      "intent": "WatchVideo",
+      "slots": [
+        {
+          "name": "Movie",
+          "type": "MOVIES"
+        }
+      ]
     },
     {
       "intent": "WatchEpisode",

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -654,6 +654,7 @@ ListenToArtist spiele Songs von der Gruppe {Artist}
 ListenToArtist spiele Songs von der Komponistin {Artist}
 ListenToArtist spiele Songs von der Künstlerin {Artist}
 ListenToArtist spiele Songs von {Artist}
+ListenToAudio anhören {Artist}
 ListenToAudioPlaylist spiel Lieder playlist {AudioPlaylist}
 ListenToAudioPlaylist spiel Musik playlist {AudioPlaylist}
 ListenToAudioPlaylist spiel Song playlist {AudioPlaylist}
@@ -805,6 +806,8 @@ PartyMode spiele zufällige Lieder
 PartyMode spiele zufällige Mucke
 PartyMode spiele zufällige Musik
 PartyMode spiele zufällige Songs
+PlayMedia spiel {Movie}
+PlayMedia spiele {Movie}
 PlayerMoveDown geh nach unten
 PlayerMoveDown geh runter
 PlayerMoveDown gehe nach unten
@@ -1198,6 +1201,7 @@ WatchRandomMovie zeige Film
 WatchRandomMovie zeige zufälligen Film
 WatchRandomMovie zeige zufälligen {Genre} Film
 WatchRandomMovie zeige {Genre} Film
+WatchVideo zeige {Movie}
 WatchVideoPlaylist zeige Film playlist {VideoPlaylist}
 WatchVideoPlaylist zeige Serie playlist {VideoPlaylist}
 WatchVideoPlaylist zeige Video playlist {VideoPlaylist}

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -316,6 +316,7 @@ ListenToArtist play artist {Artist}
 ListenToArtist play music by {Artist}
 ListenToArtist shuffle artist {Artist}
 ListenToArtist shuffle music by {Artist}
+ListenToAudio listen to {Artist}
 ListenToAudioPlaylist listen to audio playlist {AudioPlaylist}
 ListenToAudioPlaylist listen to music playlist {AudioPlaylist}
 ListenToAudioPlaylist listen to playlist {AudioPlaylist}
@@ -404,6 +405,7 @@ PartyMode listen to random music
 PartyMode play all music
 PartyMode play random music
 PartyMode shuffle all music
+PlayMedia play {Movie}
 PlayerMoveDown move down
 PlayerMoveDown pan down
 PlayerMoveDown track down
@@ -723,6 +725,7 @@ WatchRandomMovie watch random film
 WatchRandomMovie watch random movie
 WatchRandomMovie watch random {Genre} film
 WatchRandomMovie watch random {Genre} movie
+WatchVideo watch {Movie}
 WatchVideoPlaylist play movie playlist {VideoPlaylist}
 WatchVideoPlaylist play show playlist {VideoPlaylist}
 WatchVideoPlaylist play the movie playlist {VideoPlaylist}

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -112,6 +112,8 @@ open_remote: "Starte Ferbedienungs Modus, zum benutzen sage gehe nach oben, gehe
 
 help: "Du kannst mich fragen ob es neue Serien gibt, einen Film, Serie oder Sänger zu spielen, oder die Wiedergabe von Medien zu bedienen."
 
+help_play: "Please specify the media type in your play command, such as, play the movie ghost busters."
+
 are_you_sure: "Are you sure?"
 
 what_to_do: "Was möchtest Du tun?"

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -112,6 +112,8 @@ open_remote: "Starting remote control mode, to use say go up, go back as if you 
 
 help: "You can ask me whether there are any new shows, to play a movie, tv show, or artist, or control playback of media."
 
+help_play: "Please specify the media type in your play command, such as, play the movie ghost busters."
+
 are_you_sure: "Are you sure?"
 
 what_to_do: "What would you like to do?"

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -69,7 +69,11 @@ CleanAudio (Audio/Musik) Bibliothek säubern
 UpdateAudio (erneuer(/e)/refresh(/e)/update) (Audio/Musik) Bibliothek
 UpdateVideo (Audio/Musik) Bibliothek (erneuern/refreshen/updaten)
 
+PlayMedia spiel(/e) {Movie}
+
 WhatAlbums (welches Album/welche (Alben/CD/CDs/Platte/Platten)) (ich von {Artist} habe/wir von {Artist} haben/du von {Artist} hast)
+
+ListenToAudio anhören {Artist}
 
 ListenToArtist spiel(/e) (Musik/Lieder/Songs/Mucke) von (/dem Artist/der Artistin/dem Komponist/der Komponistin/dem Künstler/der Künstlerin/der Band/der Gruppe) {Artist}
 
@@ -86,6 +90,8 @@ ListenToAudioPlaylist spiel(/e) {AudioPlaylist} (Musik/Lieder/Song) playlist
 
 ListenToAudioPlaylistRecent spiel(/e) neue (Musik/Lieder/Songs)
 ListenToAudioPlaylistRecent spiel(/e) (zuletzt/kürzlich) hinzugefügte (Musik/Lieder/Songs)
+
+WatchVideo zeige {Movie}
 
 WatchRandomMovie zeige (/zufälligen) (/{Genre}) Film
 

--- a/utterances.txt
+++ b/utterances.txt
@@ -70,7 +70,11 @@ CleanAudio clean (audio/music) library
 
 UpdateAudio update (audio/music) library
 
+PlayMedia play {Movie}
+
 WhatAlbums what albums (/do) (we/i/you) have by {Artist}
+
+ListenToAudio listen to {Artist}
 
 ListenToArtist (play/listen to/shuffle) (music by/artist) {Artist}
 
@@ -90,6 +94,8 @@ ListenToAudioPlaylist listen to {AudioPlaylist} playlist
 
 ListenToAudioPlaylistRecent (play/listen to/shuffle) recent (songs/music/audio/albums)
 ListenToAudioPlaylistRecent (play/listen to/shuffle) recently added (songs/music/audio/albums)
+
+WatchVideo watch {Movie}
 
 WatchRandomMovie (play/watch) (/a) random (/{Genre}) (movie/film)
 


### PR DESCRIPTION
Instead of simply failing if the skill can't determine the media type the user requested, let's try to search deeper.

If the user specifies the media type, with something like, "Alexa, ask Kodi to play the movie Ghostbusters," then nothing changes.  But if the user says something like, "Alexa, ask Kodi to play/watch Ghostbusters," we should try to search further to find something that matches what they requested.

This PR tries to do that.

It isn't perfect and probably never will be, mostly because Amazon has a foot-hold over the "play" verb.  But, it works well enough for that, and very well if you use the alternate verbs, "watch" and "listen to."