### PR TITLE
Fix error getting timezone and shutdown vars.

### DIFF
--- a/alexa.py
+++ b/alexa.py
@@ -149,7 +149,7 @@ def alexa_current_playitem_time_remaining():
       response_text = 'There is one minute remaining.'
     elif minsleft > 1:
       response_text = 'There are %d minutes remaining' % (minsleft)
-      tz = config.get(kodi.deviceId, 'timezone')
+      tz = config.get(kodi.dev_cfg_section, 'timezone')
       if minsleft > 9 and tz and tz != 'None':
         utctime = datetime.datetime.now(pytz.utc)
         loctime = utctime.astimezone(pytz.timezone(tz))
@@ -221,7 +221,7 @@ def alexa_no():
 def alexa_yes():
   kodi = Kodi(config, context)
   if 'shutting_down' in session.attributes:
-    quit = config.get(kodi.deviceId, 'shutdown')
+    quit = config.get(kodi.dev_cfg_section, 'shutdown')
     if quit and quit == 'quit':
       card_title = render_template('quitting').encode("utf-8")
       kodi.ApplicationQuit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn
 pytz
 flask-ask>=0.8.9
-kodi-voice
+kodi-voice>=0.7.9


### PR DESCRIPTION
When the device ID isn't explicitly configured in kodi.config.

This needs Kodi-Voice 0.7.9 before we can merge it (see m0ngr31/kodi-voice/pull/2)