### PR TITLE
Remove OpenRemote Intent.

### DIFF
--- a/alexa.py
+++ b/alexa.py
@@ -1138,9 +1138,8 @@ def alexa_player_move_up():
 
   kodi = Kodi(config, context)
   kodi.PlayerMoveUp()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerMoveDown intent.
@@ -1151,9 +1150,8 @@ def alexa_player_move_down():
 
   kodi = Kodi(config, context)
   kodi.PlayerMoveDown()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerMoveLeft intent.
@@ -1164,9 +1162,8 @@ def alexa_player_move_left():
 
   kodi = Kodi(config, context)
   kodi.PlayerMoveLeft()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerMoveRight intent.
@@ -1177,9 +1174,8 @@ def alexa_player_move_right():
 
   kodi = Kodi(config, context)
   kodi.PlayerMoveRight()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerRotateClockwise intent.
@@ -1190,9 +1186,8 @@ def alexa_player_rotate_clockwise():
 
   kodi = Kodi(config, context)
   kodi.PlayerRotateClockwise()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerRotateCounterClockwise intent.
@@ -1203,9 +1198,8 @@ def alexa_player_rotate_counterclockwise():
 
   kodi = Kodi(config, context)
   kodi.PlayerRotateCounterClockwise()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomHold intent.
@@ -1215,7 +1209,6 @@ def alexa_player_zoom_hold():
   print card_title
 
   response_text = ""
-
   return statement(response_text).simple_card(card_title, response_text)
 
 
@@ -1227,9 +1220,8 @@ def alexa_player_zoom_in():
 
   kodi = Kodi(config, context)
   kodi.PlayerZoomIn()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomInMoveUp intent.
@@ -1241,9 +1233,8 @@ def alexa_player_zoom_in_move_up():
   kodi = Kodi(config, context)
   kodi.PlayerZoomIn()
   kodi.PlayerMoveUp()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomInMoveDown intent.
@@ -1255,9 +1246,8 @@ def alexa_player_zoom_in_move_down():
   kodi = Kodi(config, context)
   kodi.PlayerZoomIn()
   kodi.PlayerMoveDown()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomInMoveLeft intent.
@@ -1269,9 +1259,8 @@ def alexa_player_zoom_in_move_left():
   kodi = Kodi(config, context)
   kodi.PlayerZoomIn()
   kodi.PlayerMoveLeft()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomInMoveRight intent.
@@ -1283,9 +1272,8 @@ def alexa_player_zoom_in_move_right():
   kodi = Kodi(config, context)
   kodi.PlayerZoomIn()
   kodi.PlayerMoveRight()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomOut intent.
@@ -1296,9 +1284,8 @@ def alexa_player_zoom_out():
 
   kodi = Kodi(config, context)
   kodi.PlayerZoomOut()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomOutMoveUp intent.
@@ -1310,9 +1297,8 @@ def alexa_player_zoom_out_move_up():
   kodi = Kodi(config, context)
   kodi.PlayerZoomOut()
   kodi.PlayerMoveUp()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomOutMoveDown intent.
@@ -1324,9 +1310,8 @@ def alexa_player_zoom_out_move_down():
   kodi = Kodi(config, context)
   kodi.PlayerZoomOut()
   kodi.PlayerMoveDown()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomOutMoveLeft intent.
@@ -1338,9 +1323,8 @@ def alexa_player_zoom_out_move_left():
   kodi = Kodi(config, context)
   kodi.PlayerZoomOut()
   kodi.PlayerMoveLeft()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomOutMoveRight intent.
@@ -1352,9 +1336,8 @@ def alexa_player_zoom_out_move_right():
   kodi = Kodi(config, context)
   kodi.PlayerZoomOut()
   kodi.PlayerMoveRight()
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PlayerZoomReset intent.
@@ -1365,21 +1348,8 @@ def alexa_player_zoom_reset():
 
   kodi = Kodi(config, context)
   kodi.PlayerZoom(1)
-  response_text = ""
-
-  return statement(response_text).simple_card(card_title, response_text)
-
-
-# Handle the OpenRemote intent.
-@ask.intent('OpenRemote')
-def alexa_open_remote():
-  card_title = render_template('open_remote_card').encode("utf-8")
-  print card_title
-
-  session.attributes['navigating'] = True
-
-  response_text = render_template('open_remote').encode("utf-8")
-  return question(response_text).reprompt("").simple_card(card_title, response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the Menu intent.
@@ -1389,12 +1359,8 @@ def alexa_context_menu():
 
   kodi = Kodi(config, context)
   kodi.Menu()
-  response_text = render_template('pause').encode("utf-8")
-
-  if not 'navigating' in session.attributes:
-    return statement(response_text)
-
-  return question(response_text).reprompt(response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the Home intent.
@@ -1404,12 +1370,8 @@ def alexa_go_home():
 
   kodi = Kodi(config, context)
   kodi.Home()
-  response_text = render_template('pause').encode("utf-8")
-
-  if not 'navigating' in session.attributes:
-    return statement(response_text)
-
-  return question(response_text).reprompt(response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the Select intent.
@@ -1419,12 +1381,8 @@ def alexa_select():
 
   kodi = Kodi(config, context)
   kodi.Select()
-  response_text = render_template('pause').encode("utf-8")
-
-  if not 'navigating' in session.attributes:
-    return statement(response_text)
-
-  return question(response_text).reprompt(response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PageUp intent.
@@ -1434,12 +1392,8 @@ def alexa_pageup():
 
   kodi = Kodi(config, context)
   kodi.PageUp()
-  response_text = render_template('pause').encode("utf-8")
-
-  if not 'navigating' in session.attributes:
-    return statement(response_text)
-
-  return question(response_text).reprompt(response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the PageDown intent.
@@ -1449,12 +1403,8 @@ def alexa_pagedown():
 
   kodi = Kodi(config, context)
   kodi.PageDown()
-  response_text = render_template('pause').encode("utf-8")
-
-  if not 'navigating' in session.attributes:
-    return statement(response_text)
-
-  return question(response_text).reprompt(response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the Left intent.
@@ -1464,12 +1414,8 @@ def alexa_left():
 
   kodi = Kodi(config, context)
   kodi.Left()
-  response_text = render_template('pause').encode("utf-8")
-
-  if not 'navigating' in session.attributes:
-    return statement(response_text)
-
-  return question(response_text).reprompt(response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the Right intent.
@@ -1479,12 +1425,8 @@ def alexa_right():
 
   kodi = Kodi(config, context)
   kodi.Right()
-  response_text = render_template('pause').encode("utf-8")
-
-  if not 'navigating' in session.attributes:
-    return statement(response_text)
-
-  return question(response_text).reprompt(response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the Up intent.
@@ -1494,12 +1436,8 @@ def alexa_up():
 
   kodi = Kodi(config, context)
   kodi.Up()
-  response_text = render_template('pause').encode("utf-8")
-
-  if not 'navigating' in session.attributes:
-    return statement(response_text)
-
-  return question(response_text).reprompt(response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the Down intent.
@@ -1509,12 +1447,8 @@ def alexa_down():
 
   kodi = Kodi(config, context)
   kodi.Down()
-  response_text = render_template('pause').encode("utf-8")
-
-  if not 'navigating' in session.attributes:
-    return statement(response_text)
-
-  return question(response_text).reprompt(response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the Back intent.
@@ -1524,12 +1458,8 @@ def alexa_back():
 
   kodi = Kodi(config, context)
   kodi.Back()
-  response_text = render_template('pause').encode("utf-8")
-
-  if not 'navigating' in session.attributes:
-    return statement(response_text)
-
-  return question(response_text).reprompt(response_text)
+  response_text = render_template('confirmed').encode("utf-8")
+  return question(response_text)
 
 
 # Handle the Shutdown intent.

--- a/alexa.py
+++ b/alexa.py
@@ -68,7 +68,10 @@ def alexa_new_show_inquiry(Show):
   else:
     response_text = render_template('could_not_find', heard_name=Show).encode("utf-8")
 
-  return statement(response_text).simple_card(card_title, response_text)
+  if not 'queries_keep_open' in session.attributes:
+    return statement(response_text).simple_card(card_title, response_text)
+
+  return question(response_text)
 
 
 # Handle the CurrentPlayItemInquiry intent.
@@ -1503,7 +1506,10 @@ def alexa_ejectmedia():
   kodi = Kodi(config, context)
   kodi.SystemEjectMedia()
 
-  return statement(card_title).simple_card(card_title, "")
+  if not 'queries_keep_open' in session.attributes:
+    return statement(card_title).simple_card(card_title, '')
+
+  return question(card_title)
 
 
 # Handle the CleanVideo intent.
@@ -1627,7 +1633,10 @@ def alexa_addon_globalsearch(Movie, Show, Artist, Album, Song):
   else:
     response_text = render_template('could_not_find_generic').encode("utf-8")
 
-  return statement(response_text).simple_card(card_title, response_text)
+  if not 'queries_keep_open' in session.attributes:
+    return statement(response_text).simple_card(card_title, response_text)
+
+  return question(response_text).reprompt(response_text)
 
 
 # Handle the WatchVideo intent.
@@ -1997,7 +2006,10 @@ def alexa_what_new_albums():
       album_list += render_template('and') + limited_new_album_names[-1]
     response_text = render_template('you_have_list', items=album_list).encode("utf-8")
 
-  return statement(response_text).simple_card(card_title, response_text)
+  if not 'queries_keep_open' in session.attributes:
+    return statement(response_text).simple_card(card_title, response_text)
+
+  return question(response_text)
 
 
 # Handle the WhatNewMovies intent.
@@ -2043,7 +2055,10 @@ def alexa_what_new_movies(Genre):
       movie_list += render_template('and') + limited_new_movie_names[-1]
     response_text = render_template('you_have_list', items=movie_list).encode("utf-8")
 
-  return statement(response_text).simple_card(card_title, response_text)
+  if not 'queries_keep_open' in session.attributes:
+    return statement(response_text).simple_card(card_title, response_text)
+
+  return question(response_text)
 
 
 # Handle the WhatNewShows intent.
@@ -2087,7 +2102,10 @@ def alexa_what_new_episodes():
       show_list += render_template('and') + limited_new_show_names[-1]
     response_text = render_template('you_have_episode_list', items=show_list).encode("utf-8")
 
-  return statement(response_text).simple_card(card_title, response_text)
+  if not 'queries_keep_open' in session.attributes:
+    return statement(response_text).simple_card(card_title, response_text)
+
+  return question(response_text)
 
 
 # Handle the WhatAlbums intent.
@@ -2116,7 +2134,10 @@ def alexa_what_albums(Artist):
   else:
     response_text = render_template('could_not_find', heard_name=Artist).encode("utf-8")
 
-  return statement(response_text).simple_card(card_title, response_text)
+  if not 'queries_keep_open' in session.attributes:
+    return statement(response_text).simple_card(card_title, response_text)
+
+  return question(response_text)
 
 
 @ask.intent('AMAZON.HelpIntent')
@@ -2126,16 +2147,22 @@ def prepare_help_message():
   card_title = render_template('help_card').encode("utf-8")
   print card_title
 
+  if not 'queries_keep_open' in session.attributes:
+    return statement(response_text).simple_card(card_title, response_text)
+
   return question(response_text).reprompt(reprompt_text)
 
 
 # No intents invoked
 @ask.launch
-def prepare_help_message():
+def alexa_launch():
   response_text = render_template('welcome').encode("utf-8")
   reprompt_text = render_template('what_to_do').encode("utf-8")
   card_title = response_text
   print card_title
+
+  # All non-playback requests should keep the session open
+  session.attributes['queries_keep_open'] = True
 
   return question(response_text).reprompt(reprompt_text)
 

--- a/alexa.py
+++ b/alexa.py
@@ -1141,7 +1141,7 @@ def alexa_player_move_up():
 
   kodi = Kodi(config, context)
   kodi.PlayerMoveUp()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1153,7 +1153,7 @@ def alexa_player_move_down():
 
   kodi = Kodi(config, context)
   kodi.PlayerMoveDown()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1165,7 +1165,7 @@ def alexa_player_move_left():
 
   kodi = Kodi(config, context)
   kodi.PlayerMoveLeft()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1177,7 +1177,7 @@ def alexa_player_move_right():
 
   kodi = Kodi(config, context)
   kodi.PlayerMoveRight()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1189,7 +1189,7 @@ def alexa_player_rotate_clockwise():
 
   kodi = Kodi(config, context)
   kodi.PlayerRotateClockwise()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1201,7 +1201,7 @@ def alexa_player_rotate_counterclockwise():
 
   kodi = Kodi(config, context)
   kodi.PlayerRotateCounterClockwise()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1223,7 +1223,7 @@ def alexa_player_zoom_in():
 
   kodi = Kodi(config, context)
   kodi.PlayerZoomIn()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1236,7 +1236,7 @@ def alexa_player_zoom_in_move_up():
   kodi = Kodi(config, context)
   kodi.PlayerZoomIn()
   kodi.PlayerMoveUp()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1249,7 +1249,7 @@ def alexa_player_zoom_in_move_down():
   kodi = Kodi(config, context)
   kodi.PlayerZoomIn()
   kodi.PlayerMoveDown()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1262,7 +1262,7 @@ def alexa_player_zoom_in_move_left():
   kodi = Kodi(config, context)
   kodi.PlayerZoomIn()
   kodi.PlayerMoveLeft()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1275,7 +1275,7 @@ def alexa_player_zoom_in_move_right():
   kodi = Kodi(config, context)
   kodi.PlayerZoomIn()
   kodi.PlayerMoveRight()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1287,7 +1287,7 @@ def alexa_player_zoom_out():
 
   kodi = Kodi(config, context)
   kodi.PlayerZoomOut()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1300,7 +1300,7 @@ def alexa_player_zoom_out_move_up():
   kodi = Kodi(config, context)
   kodi.PlayerZoomOut()
   kodi.PlayerMoveUp()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1313,7 +1313,7 @@ def alexa_player_zoom_out_move_down():
   kodi = Kodi(config, context)
   kodi.PlayerZoomOut()
   kodi.PlayerMoveDown()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1326,7 +1326,7 @@ def alexa_player_zoom_out_move_left():
   kodi = Kodi(config, context)
   kodi.PlayerZoomOut()
   kodi.PlayerMoveLeft()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1339,7 +1339,7 @@ def alexa_player_zoom_out_move_right():
   kodi = Kodi(config, context)
   kodi.PlayerZoomOut()
   kodi.PlayerMoveRight()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1351,7 +1351,7 @@ def alexa_player_zoom_reset():
 
   kodi = Kodi(config, context)
   kodi.PlayerZoom(1)
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1362,7 +1362,7 @@ def alexa_context_menu():
 
   kodi = Kodi(config, context)
   kodi.Menu()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1373,7 +1373,7 @@ def alexa_go_home():
 
   kodi = Kodi(config, context)
   kodi.Home()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1384,7 +1384,7 @@ def alexa_select():
 
   kodi = Kodi(config, context)
   kodi.Select()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1395,7 +1395,7 @@ def alexa_pageup():
 
   kodi = Kodi(config, context)
   kodi.PageUp()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1406,7 +1406,7 @@ def alexa_pagedown():
 
   kodi = Kodi(config, context)
   kodi.PageDown()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1417,7 +1417,7 @@ def alexa_left():
 
   kodi = Kodi(config, context)
   kodi.Left()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1428,7 +1428,7 @@ def alexa_right():
 
   kodi = Kodi(config, context)
   kodi.Right()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1439,7 +1439,7 @@ def alexa_up():
 
   kodi = Kodi(config, context)
   kodi.Up()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1450,7 +1450,7 @@ def alexa_down():
 
   kodi = Kodi(config, context)
   kodi.Down()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 
@@ -1461,7 +1461,7 @@ def alexa_back():
 
   kodi = Kodi(config, context)
   kodi.Back()
-  response_text = render_template('confirmed').encode("utf-8")
+  response_text = render_template('short_confirm').encode("utf-8")
   return question(response_text)
 
 

--- a/alexa.py
+++ b/alexa.py
@@ -42,38 +42,6 @@ ask = Ask(app, "/", None, path=TEMPLATE_FILE)
 
 # Start of intent methods
 
-# Handle the NewShowInquiry intent.
-@ask.intent('NewShowInquiry')
-def alexa_new_show_inquiry(Show):
-  card_title = render_template('looking_for_show', heard_show=Show).encode("utf-8")
-  print card_title
-
-  kodi = Kodi(config, context)
-  show_id, show_label = kodi.FindTvShow(Show)
-  if show_id:
-    episodes_result = kodi.GetUnwatchedEpisodesFromShow(show_id)
-
-    if not 'episodes' in episodes_result['result']:
-      num_of_unwatched = 0
-    else:
-      num_of_unwatched = len(episodes_result['result']['episodes'])
-
-    if num_of_unwatched > 0:
-      if num_of_unwatched == 1:
-        response_text = render_template('one_unseen_show', show_name=show_label).encode("utf-8")
-      else:
-        response_text = render_template('multiple_unseen_show', show_name=show_label, num=num_of_unwatched).encode("utf-8")
-    else:
-      response_text = render_template('no_unseen_show', show_name=show_label).encode("utf-8")
-  else:
-    response_text = render_template('could_not_find', heard_name=Show).encode("utf-8")
-
-  if not 'queries_keep_open' in session.attributes:
-    return statement(response_text).simple_card(card_title, response_text)
-
-  return question(response_text)
-
-
 # Handle the CurrentPlayItemInquiry intent.
 @ask.intent('CurrentPlayItemInquiry')
 def alexa_current_playitem_inquiry():
@@ -2101,6 +2069,38 @@ def alexa_what_new_episodes():
     elif num_shows > 1:
       show_list += render_template('and') + limited_new_show_names[-1]
     response_text = render_template('you_have_episode_list', items=show_list).encode("utf-8")
+
+  if not 'queries_keep_open' in session.attributes:
+    return statement(response_text).simple_card(card_title, response_text)
+
+  return question(response_text)
+
+
+# Handle the WhatNewEpisodes intent.
+@ask.intent('WhatNewEpisodes')
+def alexa_what_new_episodes(Show):
+  card_title = render_template('looking_for_show', heard_show=Show).encode("utf-8")
+  print card_title
+
+  kodi = Kodi(config, context)
+  show_id, show_label = kodi.FindTvShow(Show)
+  if show_id:
+    episodes_result = kodi.GetUnwatchedEpisodesFromShow(show_id)
+
+    if not 'episodes' in episodes_result['result']:
+      num_of_unwatched = 0
+    else:
+      num_of_unwatched = len(episodes_result['result']['episodes'])
+
+    if num_of_unwatched > 0:
+      if num_of_unwatched == 1:
+        response_text = render_template('one_unseen_show', show_name=show_label).encode("utf-8")
+      else:
+        response_text = render_template('multiple_unseen_show', show_name=show_label, num=num_of_unwatched).encode("utf-8")
+    else:
+      response_text = render_template('no_unseen_show', show_name=show_label).encode("utf-8")
+  else:
+    response_text = render_template('could_not_find', heard_name=Show).encode("utf-8")
 
   if not 'queries_keep_open' in session.attributes:
     return statement(response_text).simple_card(card_title, response_text)

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -363,9 +363,6 @@
       ]
     },
     {
-      "intent": "OpenRemote"
-    },
-    {
       "intent": "Home"
     },
     {

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -16,7 +16,7 @@
       "intent": "WhatNewShows"
     },
     {
-      "intent": "NewShowInquiry",
+      "intent": "WhatNewEpisodes",
       "slots": [
         {
           "name": "Show",

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -496,8 +496,6 @@ NewShowInquiry ob wir neue Folgen von {Show} haben
 NewShowInquiry ob wir neue Folgen {Show} haben
 NewShowInquiry ob wir neue von {Show} haben
 NewShowInquiry ob wir neue {Show} haben
-OpenRemote öffne Controller
-OpenRemote öffne Fernbedienung
 PageDown Seite nach unten
 PageDown Seite runter
 PageDown navigier Seite nach unten

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -460,42 +460,6 @@ Mute ton an
 Mute ton anschalten
 Mute ton aus
 Mute ton ausschalten
-NewShowInquiry ob du eine neue Episode von {Show} hast
-NewShowInquiry ob du eine neue Episode {Show} hast
-NewShowInquiry ob du eine neue Folge von {Show} hast
-NewShowInquiry ob du eine neue Folge {Show} hast
-NewShowInquiry ob du eine neue von {Show} hast
-NewShowInquiry ob du eine neue {Show} hast
-NewShowInquiry ob du neue Episoden von {Show} hast
-NewShowInquiry ob du neue Episoden {Show} hast
-NewShowInquiry ob du neue Folgen von {Show} hast
-NewShowInquiry ob du neue Folgen {Show} hast
-NewShowInquiry ob du neue von {Show} hast
-NewShowInquiry ob du neue {Show} hast
-NewShowInquiry ob es eine neue Episode von {Show} gibt
-NewShowInquiry ob es eine neue Episode {Show} gibt
-NewShowInquiry ob es eine neue Folge von {Show} gibt
-NewShowInquiry ob es eine neue Folge {Show} gibt
-NewShowInquiry ob es eine neue von {Show} gibt
-NewShowInquiry ob es eine neue {Show} gibt
-NewShowInquiry ob es neue Episoden von {Show} gibt
-NewShowInquiry ob es neue Episoden {Show} gibt
-NewShowInquiry ob es neue Folgen von {Show} gibt
-NewShowInquiry ob es neue Folgen {Show} gibt
-NewShowInquiry ob es neue von {Show} gibt
-NewShowInquiry ob es neue {Show} gibt
-NewShowInquiry ob wir eine neue Episode von {Show} haben
-NewShowInquiry ob wir eine neue Episode {Show} haben
-NewShowInquiry ob wir eine neue Folge von {Show} haben
-NewShowInquiry ob wir eine neue Folge {Show} haben
-NewShowInquiry ob wir eine neue von {Show} haben
-NewShowInquiry ob wir eine neue {Show} haben
-NewShowInquiry ob wir neue Episoden von {Show} haben
-NewShowInquiry ob wir neue Episoden {Show} haben
-NewShowInquiry ob wir neue Folgen von {Show} haben
-NewShowInquiry ob wir neue Folgen {Show} haben
-NewShowInquiry ob wir neue von {Show} haben
-NewShowInquiry ob wir neue {Show} haben
 PageDown Seite nach unten
 PageDown Seite runter
 PageDown navigier Seite nach unten
@@ -1019,6 +983,42 @@ WhatNewAlbums welche neuen Alben warten
 WhatNewAlbums welches neue Album aufgenommen worden ist
 WhatNewAlbums welches neue Album fertig ist
 WhatNewAlbums welches neue Album wartet
+WhatNewEpisodes ob du eine neue Episode von {Show} hast
+WhatNewEpisodes ob du eine neue Episode {Show} hast
+WhatNewEpisodes ob du eine neue Folge von {Show} hast
+WhatNewEpisodes ob du eine neue Folge {Show} hast
+WhatNewEpisodes ob du eine neue von {Show} hast
+WhatNewEpisodes ob du eine neue {Show} hast
+WhatNewEpisodes ob du neue Episoden von {Show} hast
+WhatNewEpisodes ob du neue Episoden {Show} hast
+WhatNewEpisodes ob du neue Folgen von {Show} hast
+WhatNewEpisodes ob du neue Folgen {Show} hast
+WhatNewEpisodes ob du neue von {Show} hast
+WhatNewEpisodes ob du neue {Show} hast
+WhatNewEpisodes ob es eine neue Episode von {Show} gibt
+WhatNewEpisodes ob es eine neue Episode {Show} gibt
+WhatNewEpisodes ob es eine neue Folge von {Show} gibt
+WhatNewEpisodes ob es eine neue Folge {Show} gibt
+WhatNewEpisodes ob es eine neue von {Show} gibt
+WhatNewEpisodes ob es eine neue {Show} gibt
+WhatNewEpisodes ob es neue Episoden von {Show} gibt
+WhatNewEpisodes ob es neue Episoden {Show} gibt
+WhatNewEpisodes ob es neue Folgen von {Show} gibt
+WhatNewEpisodes ob es neue Folgen {Show} gibt
+WhatNewEpisodes ob es neue von {Show} gibt
+WhatNewEpisodes ob es neue {Show} gibt
+WhatNewEpisodes ob wir eine neue Episode von {Show} haben
+WhatNewEpisodes ob wir eine neue Episode {Show} haben
+WhatNewEpisodes ob wir eine neue Folge von {Show} haben
+WhatNewEpisodes ob wir eine neue Folge {Show} haben
+WhatNewEpisodes ob wir eine neue von {Show} haben
+WhatNewEpisodes ob wir eine neue {Show} haben
+WhatNewEpisodes ob wir neue Episoden von {Show} haben
+WhatNewEpisodes ob wir neue Episoden {Show} haben
+WhatNewEpisodes ob wir neue Folgen von {Show} haben
+WhatNewEpisodes ob wir neue Folgen {Show} haben
+WhatNewEpisodes ob wir neue von {Show} haben
+WhatNewEpisodes ob wir neue {Show} haben
 WhatNewMovies ob es einen neuen Film gibt
 WhatNewMovies ob es einen neuen {Genre} Film gibt
 WhatNewMovies ob es neue Filme gibt

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -188,14 +188,6 @@ Mute set unmute
 Mute toggle mute
 Mute toggle unmute
 Mute unmute
-NewShowInquiry if there are any episodes of {Show}
-NewShowInquiry if there are any new episodes of {Show}
-NewShowInquiry if there is a new episode of {Show}
-NewShowInquiry if there is an episode of {Show}
-NewShowInquiry if we have a new episode of {Show}
-NewShowInquiry if we have an episode of {Show}
-NewShowInquiry if we have any episodes of {Show}
-NewShowInquiry if we have any new episodes of {Show}
 PageDown go page down
 PageDown navigate page down
 PageDown page down
@@ -583,6 +575,14 @@ WhatNewAlbums what new albums are there
 WhatNewAlbums what new albums are there to listen to
 WhatNewAlbums what new albums do i have
 WhatNewAlbums what new albums do i have to listen to
+WhatNewEpisodes if there are any episodes of {Show}
+WhatNewEpisodes if there are any new episodes of {Show}
+WhatNewEpisodes if there is a new episode of {Show}
+WhatNewEpisodes if there is an episode of {Show}
+WhatNewEpisodes if we have a new episode of {Show}
+WhatNewEpisodes if we have an episode of {Show}
+WhatNewEpisodes if we have any episodes of {Show}
+WhatNewEpisodes if we have any new episodes of {Show}
 WhatNewMovies are there any new {Genre} films
 WhatNewMovies are there any new {Genre} films recorded
 WhatNewMovies are there any new {Genre} films recorded to watch

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -196,9 +196,6 @@ NewShowInquiry if we have a new episode of {Show}
 NewShowInquiry if we have an episode of {Show}
 NewShowInquiry if we have any episodes of {Show}
 NewShowInquiry if we have any new episodes of {Show}
-OpenRemote open controller
-OpenRemote open controls
-OpenRemote open remote
 PageDown go page down
 PageDown navigate page down
 PageDown page down

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -318,7 +318,7 @@ remaining_time: ", und die Wiedergabe wird um {{ end_time }} enden"
 ##   General Templates    ##
 ############################
 
-confirmed: " "
+short_confirm: " "
 
 and_more: ", und mehr"
 

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -116,8 +116,6 @@ you_have_episode_list: "Es gibt neue Folgen für {{ items }}"
 
 volume_set: "Lautstärke auf {{ num }} gestellt"
 
-open_remote: "Starte Fernbedienungs-Modus, zum Benutzen sage gehe nach oben oder gehe zurück, so als wenn Du die Fernbedienung benutzen würdest, sage Stopp um den Fernbedienungs-Modus zu verlassen"
-
 help: "Du kannst mich fragen ob es neue Serien gibt, einen Film, Serie oder Sänger zu spielen, oder die Wiedergabe von Medien zu bedienen"
 
 help_play: "Spezifiziere bitte den Medientyp mit dem Wiedergabebefehl, so wie Spiele den Film Ghost Busters"
@@ -301,8 +299,6 @@ search: "Suche"
 
 help_card: "Hilfe"
 
-open_remote_card: "Öffne Fernbedienung"
-
 playback_stopped: "Wiedergabe gestoppt"
 
 unknown_playing: "Der Titel der aktuellen Wiedergabe ist unbekannt"
@@ -322,7 +318,7 @@ remaining_time: ", und die Wiedergabe wird um {{ end_time }} enden"
 ##   General Templates    ##
 ############################
 
-pause: " "
+confirmed: " "
 
 and_more: ", und mehr"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -318,7 +318,7 @@ remaining_time: ", and it will end at {{ end_time }}"
 ##   General Templates    ##
 ############################
 
-confirmed: " "
+short_confirm: " "
 
 and_more: ", and more"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -116,8 +116,6 @@ you_have_episode_list: "There are new episodes of {{ items }}"
 
 volume_set: "Volume set to {{ num }}"
 
-open_remote: "Starting remote control mode, to use say go up, go back as if you were pressing buttons, say stop to exit control mode"
-
 help: "You can ask me whether there are any new shows, to play a movie, tv show, or artist, or control playback of media."
 
 help_play: "Please specify the media type in your play command, such as, play the movie ghost busters."
@@ -301,8 +299,6 @@ search: "Search"
 
 help_card: "Help"
 
-open_remote_card: "Opening remote"
-
 playback_stopped: "Playback stopped"
 
 unknown_playing: "The currently playing item is unknown"
@@ -322,7 +318,7 @@ remaining_time: ", and it will end at {{ end_time }}"
 ##   General Templates    ##
 ############################
 
-pause: " "
+confirmed: " "
 
 and_more: ", and more"
 

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -151,12 +151,12 @@ WhatNewShows welche (/neue) Serie (wartet/(fertig/aufgenommen worden) ist)
 WhatNewShows welche neuen Serien (warten/(fertig/aufgenommen worden) sind)
 WhatNewShows welche (neue Serie/neuen Serien) (habe ich/haben wir/gibt es/ich habe/wir haben/es gibt)
 
-NewShowInquiry ob es eine neue (/Episode/Folge) (/von) {Show} gibt
-NewShowInquiry ob wir eine neue (/Episode/Folge) (/von) {Show} haben
-NewShowInquiry ob du eine neue (/Episode/Folge) (/von) {Show} hast
-NewShowInquiry ob es neue (/Episoden/Folgen) (/von) {Show} gibt
-NewShowInquiry ob wir neue (/Episoden/Folgen) (/von) {Show} haben
-NewShowInquiry ob du neue (/Episoden/Folgen) (/von) {Show} hast
+WhatNewEpisodes ob es eine neue (/Episode/Folge) (/von) {Show} gibt
+WhatNewEpisodes ob wir eine neue (/Episode/Folge) (/von) {Show} haben
+WhatNewEpisodes ob du eine neue (/Episode/Folge) (/von) {Show} hast
+WhatNewEpisodes ob es neue (/Episoden/Folgen) (/von) {Show} gibt
+WhatNewEpisodes ob wir neue (/Episoden/Folgen) (/von) {Show} haben
+WhatNewEpisodes ob du neue (/Episoden/Folgen) (/von) {Show} hast
 
 PartyMode (zufallswiedergabe/spiel(/e) (/zufällige/irgendwelche)) (Musik/Lieder/Songs/Mucke)
 PartyMode leg(/e) (/zufällige/irgendwelche) (Musik/Lieder/Songs/Mucke) auf

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -207,5 +207,3 @@ AddonGlobalSearch suche nach {Show}
 AddonGlobalSearch suche nach {Movie}
 AddonGlobalSearch suche nach {Album}
 AddonGlobalSearch suche nach {Artist}
-
-OpenRemote öffne (Fernbedienung/Controller)

--- a/utterances.txt
+++ b/utterances.txt
@@ -155,8 +155,8 @@ WhatNewShows (if there are/are there/do i have) new shows (/to watch)
 WhatNewShows (if there is/is there/do i have) a new show (/to watch)
 WhatNewShows what new shows (do i have/are there) (/to watch)
 
-NewShowInquiry if (there is/we have) (a new/an) episode of {Show}
-NewShowInquiry if (there are/we have) any (/new) episodes of {Show}
+WhatNewEpisodes if (there is/we have) (a new/an) episode of {Show}
+WhatNewEpisodes if (there are/we have) any (/new) episodes of {Show}
 
 PartyMode listen to random music
 PartyMode listen to all music

--- a/utterances.txt
+++ b/utterances.txt
@@ -200,5 +200,3 @@ AddonGlobalSearch search for {Show}
 AddonGlobalSearch search for {Movie}
 AddonGlobalSearch search for {Album}
 AddonGlobalSearch search for {Artist}
-
-OpenRemote open (remote/controls/controller)


### PR DESCRIPTION
Instead, all navigation commands now by default leave the session open.

Nearly every time I've used one of the nav commands, I've followed it with more.  To me, it makes sense to just leave the session open whenever a nav command is issued.

Further, the user can also begin a session by simply opening the skill with no command ("open kodi"), and with the above, the session will stay open if it receives a navigation command first, so there doesn't seem to be much need for an explicit "open remote" intent.