### PR TITLE
Add Recommend* Intents.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn
 pytz
 flask-ask>=0.8.9
-kodi-voice>=0.8.3
+kodi-voice>=0.8.4

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -1,6 +1,30 @@
 {
   "intents": [
     {
+      "intent": "RecommendMedia"
+    },
+    {
+      "intent": "RecommendMovie"
+    },
+    {
+      "intent": "RecommendShow"
+    },
+    {
+      "intent": "RecommendEpisode"
+    },
+    {
+      "intent": "RecommendMusicVideo"
+    },
+    {
+      "intent": "RecommendArtist"
+    },
+    {
+      "intent": "RecommendAlbum"
+    },
+    {
+      "intent": "RecommendSong"
+    },
+    {
       "intent": "WhatNewAlbums"
     },
     {

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -822,6 +822,46 @@ Reboot neustarten
 Reboot reboot
 Reboot system neustarten
 Reboot system reboot
+RecommendAlbum welches Album es empfiehlt
+RecommendAlbum welches Album es mir empfiehlt
+RecommendAlbum welches Album es mir vorschlägt
+RecommendAlbum welches Album es vorschlägt
+RecommendArtist welchen Interpreten es empfiehlt
+RecommendArtist welchen Interpreten es mir empfiehlt
+RecommendArtist welchen Interpreten es mir vorschlägt
+RecommendArtist welchen Interpreten es vorschlägt
+RecommendEpisode welche Episode es empfiehlt
+RecommendEpisode welche Episode es mir empfiehlt
+RecommendEpisode welche Episode es mir vorschlägt
+RecommendEpisode welche Episode es vorschlägt
+RecommendEpisode welche Folge es empfiehlt
+RecommendEpisode welche Folge es mir empfiehlt
+RecommendEpisode welche Folge es mir vorschlägt
+RecommendEpisode welche Folge es vorschlägt
+RecommendMedia was es empfiehlt
+RecommendMedia was es mir empfiehlt
+RecommendMedia was es mir vorschlägt
+RecommendMedia was es vorschlägt
+RecommendMovie welchen Film es empfiehlt
+RecommendMovie welchen Film es mir empfiehlt
+RecommendMovie welchen Film es mir vorschlägt
+RecommendMovie welchen Film es vorschlägt
+RecommendMusicVideo welches Musikvideo es empfiehlt
+RecommendMusicVideo welches Musikvideo es mir empfiehlt
+RecommendMusicVideo welches Musikvideo es mir vorschlägt
+RecommendMusicVideo welches Musikvideo es vorschlägt
+RecommendShow welche Serie es empfiehlt
+RecommendShow welche Serie es mir empfiehlt
+RecommendShow welche Serie es mir vorschlägt
+RecommendShow welche Serie es vorschlägt
+RecommendSong welchen Song es empfiehlt
+RecommendSong welchen Song es mir empfiehlt
+RecommendSong welchen Song es mir vorschlägt
+RecommendSong welchen Song es vorschlägt
+RecommendSong welches Lied es empfiehlt
+RecommendSong welches Lied es mir empfiehlt
+RecommendSong welches Lied es mir vorschlägt
+RecommendSong welches Lied es vorschlägt
 Right nach rechts
 Right navigier nach rechts
 Right navigier rechts

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -401,6 +401,40 @@ PlayerZoomReset normal zoom
 PlayerZoomReset reset zoom
 Reboot reboot
 Reboot reboot system
+RecommendAlbum recommend album
+RecommendAlbum suggest album
+RecommendArtist recommend artist
+RecommendArtist recommend band
+RecommendArtist recommend music artist
+RecommendArtist recommend musician
+RecommendArtist suggest artist
+RecommendArtist suggest band
+RecommendArtist suggest music artist
+RecommendArtist suggest musician
+RecommendEpisode recommend episode
+RecommendEpisode recommend t. v. episode
+RecommendEpisode suggest episode
+RecommendEpisode suggest t. v. episode
+RecommendMedia recommend something
+RecommendMedia suggest something
+RecommendMovie recommend film
+RecommendMovie recommend movie
+RecommendMovie suggest film
+RecommendMovie suggest movie
+RecommendMusicVideo recommend music video
+RecommendMusicVideo suggest music video
+RecommendShow recommend show
+RecommendShow recommend t. v. show
+RecommendShow suggest show
+RecommendShow suggest t. v. show
+RecommendSong recommend music
+RecommendSong recommend some music
+RecommendSong recommend some songs
+RecommendSong recommend songs
+RecommendSong suggest music
+RecommendSong suggest some music
+RecommendSong suggest some songs
+RecommendSong suggest songs
 Right go right
 Right navigate right
 Right right

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -30,6 +30,22 @@ could_not_find_show: "Konnte die Serie {{ heard_show }} nicht finden"
 
 could_not_find_episode_show: "Konnte Staffel {{ season }} Folge {{ episode }} von {{ show_name }} nicht finden"
 
+no_recommendations: "Es tut mir leid, aber es gibt nichts zu empfehlen."
+
+recommend_movie: "Wie wäre es mit dem Film {{ movie_name }}?"
+
+recommend_show: "Wie wäre es mit der Serie {{ show_name }}?"
+
+recommend_episode: "Wie wäre es mit der Staffel {{ season }} Episode {{ episode }} von {{ show_name }}?"
+
+recommend_musicvideo: "Wie wäre es mit dem Musikvideo {{ musicvideo_name }} von {{ artist_name }}?"
+
+recommend_artist: "Wie wäre es mit Musik von {{ artist_name }}?"
+
+recommend_album: "Wie wäre es mit dem Album {{ album_name }} von {{ artist_name }}?"
+
+recommend_song: "Wie wäre es mit ein paar kürzlich hinzugefügten Songs?"
+
 searching: "Suche nach {{ heard_name }}"
 
 opening: "Öffne {{ heard_name }}"
@@ -317,6 +333,8 @@ remaining_time: ", und die Wiedergabe wird um {{ end_time }} enden"
 ############################
 ##   General Templates    ##
 ############################
+
+okay: "Okay"
 
 short_confirm: " "
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -34,6 +34,22 @@ searching: "Searching for {{ heard_name }}"
 
 opening: "Opening {{ heard_name }}"
 
+no_recommendations: "I'm sorry, I have nothing to recommend"
+
+recommend_movie: "How about the movie {{ movie_name }}?"
+
+recommend_show: "How about the show {{ show_name }}?"
+
+recommend_episode: "How about season {{ season }} episode {{ episode }} of {{ show_name }}?"
+
+recommend_musicvideo: "How about the music video {{ musicvideo_name }} by {{ artist_name }}?"
+
+recommend_artist: "How about music by {{ artist_name }}?"
+
+recommend_album: "How about the album {{ album_name }} by {{ artist_name }}?"
+
+recommend_song: "How about some of your recently added songs?"
+
 playing: "Playing {{ heard_name }}"
 
 playing_album: "Playing album {{ album_name }}"
@@ -317,6 +333,8 @@ remaining_time: ", and it will end at {{ end_time }}"
 ############################
 ##   General Templates    ##
 ############################
+
+okay: "Okay"
 
 short_confirm: " "
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -30,10 +30,6 @@ could_not_find_show: "Could not find a show named {{ heard_show }}"
 
 could_not_find_episode_show: "Could not find season {{ season }} episode {{ episode }} of {{ show_name }}"
 
-searching: "Searching for {{ heard_name }}"
-
-opening: "Opening {{ heard_name }}"
-
 no_recommendations: "I'm sorry, I have nothing to recommend"
 
 recommend_movie: "How about the movie {{ movie_name }}?"
@@ -49,6 +45,10 @@ recommend_artist: "How about music by {{ artist_name }}?"
 recommend_album: "How about the album {{ album_name }} by {{ artist_name }}?"
 
 recommend_song: "How about some of your recently added songs?"
+
+searching: "Searching for {{ heard_name }}"
+
+opening: "Opening {{ heard_name }}"
 
 playing: "Playing {{ heard_name }}"
 

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -137,6 +137,15 @@ ShufflePlaylist zufallswiedergabe {AudioPlaylist} playlist
 ShufflePlaylist zufallswiedergabe playlist {VideoPlaylist}
 ShufflePlaylist zufallswiedergabe {VideoPlaylist} playlist
 
+RecommendMedia was es (/mir) (empfiehlt/vorschlägt)
+RecommendMovie welchen Film es (/mir) (empfiehlt/vorschlägt)
+RecommendShow welche Serie es (/mir) (empfiehlt/vorschlägt)
+RecommendEpisode welche (Folge/Episode) es (/mir) (empfiehlt/vorschlägt)
+RecommendMusicVideo welches Musikvideo es (/mir) (empfiehlt/vorschlägt)
+RecommendArtist welchen Interpreten es (/mir) (empfiehlt/vorschlägt)
+RecommendAlbum welches Album es (/mir) (empfiehlt/vorschlägt)
+RecommendSong (welches Lied/welchen Song) es (/mir) (empfiehlt/vorschlägt)
+
 WhatNewAlbums welches neue Album (wartet/(fertig/aufgenommen worden) ist)
 WhatNewAlbums welche neuen Alben (warten/(fertig/aufgenommen worden) sind)
 

--- a/utterances.txt
+++ b/utterances.txt
@@ -140,6 +140,15 @@ ShufflePlaylist shuffle {AudioPlaylist} playlist
 ShufflePlaylist shuffle (/the) playlist {VideoPlaylist}
 ShufflePlaylist shuffle {VideoPlaylist} playlist
 
+RecommendMedia (suggest/recommend) something
+RecommendMovie (suggest/recommend) (movie/film)
+RecommendShow (suggest/recommend) (/t. v.) show
+RecommendEpisode (suggest/recommend) (/t. v.) episode
+RecommendMusicVideo (suggest/recommend) music video
+RecommendArtist (suggest/recommend) ((/music) artist/musician/band)
+RecommendAlbum (suggest/recommend) album
+RecommendSong (suggest/recommend) (/some) (songs/music)
+
 WhatNewAlbums (if there are/are there/do i have) new albums (/to listen to)
 WhatNewAlbums (if there is/is there/do i have) a new album (/to listen to)
 WhatNewAlbums what new albums (do i have/are there) (/to listen to)


### PR DESCRIPTION
To recommend media to the user.

Requires script.skin.helper.widgets to be installed on Kodi.  It seemed reasonable to require this as the functionality is already there, and most people will have this installed already.

These intents all support maintaining a conversation with Alexa, so you can do something like:

"Alexa, open Kodi"
"Recommend a movie"
_"How about the movie Ghostbusters?"_
"No"
_"How about the movie Back to the Future?"_
"Yes"

This additionally requires changes that are already in Kodi-Voice, but not yet released to PyPi.  I did however push up a test package with these changes (10.9.4) to the PyPi test server.