### PR TITLE
Replace all calls to Kodi.matchHeard().

### DIFF
--- a/generate_custom_slots.py
+++ b/generate_custom_slots.py
@@ -115,7 +115,7 @@ gfile.close()
 
 
 # Generate MOVIEGENRES Slot
-retrieved = kodi.GetMovieGenres()
+retrieved = kodi.GetVideoGenres()
 
 all = []
 


### PR DESCRIPTION
Stop directly calling Kodi.matchHeard() to better abstract things.  Instead, utilize the Find*() helper methods in Kodi-Voice.

This supports the trial of two methods of handling matching:

1. Kodi.matchHeard() being been moved to [script.alexa.helper](https://github.com/jingai/script.alexa.helper).  This way removes the need to transmit the library items to the skill, at the cost of off-loading the fuzzy matching to the Kodi client machine.  The addon must be installed on your Kodi clients for this to work.  This method utilizes the changes in m0ngr31/kodi-voice/pull/11

2. Optimizing matching and library item transmission in Kodi-Voice.  This is the old method, and has the benefit of potentially placing the fuzzy matching job on a more powerful machine, at the expense of having to transmit the list items.  This method utilizes the changes in _FORTHCOMING_PR_.