### PR TITLE
Add ability to specify album when playing a song.

### DIFF
--- a/alexa.py
+++ b/alexa.py
@@ -720,9 +720,10 @@ def alexa_shuffle_latest_album(Artist):
   return alexa_listen_latest_album(Artist, True)
 
 
-# Handle the ListenToSong intent (Play a song, or song by a specific artist).
+# Handle the ListenToSong intent (Play a song, song by a specific artist,
+# or song on a specific album).
 @ask.intent('ListenToSong')
-def alexa_listen_song(Song, Artist):
+def alexa_listen_song(Song, Album, Artist):
   card_title = render_template('playing_song_card').encode("utf-8")
   print card_title
 
@@ -737,6 +738,16 @@ def alexa_listen_song(Song, Artist):
         response_text = render_template('could_not_find_song_artist', song_name=Song, artist=artist_label).encode("utf-8")
     else:
       response_text = render_template('could_not_find_song_artist', song_name=Song, artist=Artist).encode("utf-8")
+  elif Album:
+    album_id, album_label = kodi.FindAlbum(Album)
+    if album_id:
+      song_id, song_label = kodi.FindSong(Song, album_id=album_id)
+      if song_id:
+        response_text = render_template('playing_song_album', song_name=song_label, album_name=album_label).encode("utf-8")
+      else:
+        response_text = render_template('could_not_find_song_album', song_name=Song, album_name=album_label).encode("utf-8")
+    else:
+      response_text = render_template('could_not_find_song_album', song_name=Song, album_name=Album).encode("utf-8")
   else:
     song_id, song_label = kodi.FindSong(Song)
     if song_id:

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -215,6 +215,10 @@
         {
           "name": "Song",
           "type": "MUSICSONGS"
+        },
+        {
+          "name": "Album",
+          "type": "MUSICALBUMS"
         }
       ]
     },

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -448,15 +448,27 @@ ListenToLatestAlbum spiele neuestes Album von {Artist}
 ListenToLatestAlbum spiele zuletzt das hinzugefügte Album von {Artist}
 ListenToLatestAlbum spiele zuletzt hinzugefügtes Album von {Artist}
 ListenToSong spiel das Lied {Song}
+ListenToSong spiel das Lied {Song} auf dem Album {Album}
+ListenToSong spiel das Lied {Song} aus dem Album {Album}
+ListenToSong spiel das Lied {Song} vom Album {Album}
 ListenToSong spiel das Lied {Song} von dem Album {Album}
 ListenToSong spiel das Lied {Song} von {Artist}
 ListenToSong spiel den Song {Song}
+ListenToSong spiel den Song {Song} auf dem Album {Album}
+ListenToSong spiel den Song {Song} aus dem Album {Album}
+ListenToSong spiel den Song {Song} vom Album {Album}
 ListenToSong spiel den Song {Song} von dem Album {Album}
 ListenToSong spiel den Song {Song} von {Artist}
 ListenToSong spiele das Lied {Song}
+ListenToSong spiele das Lied {Song} auf dem Album {Album}
+ListenToSong spiele das Lied {Song} aus dem Album {Album}
+ListenToSong spiele das Lied {Song} vom Album {Album}
 ListenToSong spiele das Lied {Song} von dem Album {Album}
 ListenToSong spiele das Lied {Song} von {Artist}
 ListenToSong spiele den Song {Song}
+ListenToSong spiele den Song {Song} auf dem Album {Album}
+ListenToSong spiele den Song {Song} aus dem Album {Album}
+ListenToSong spiele den Song {Song} vom Album {Album}
 ListenToSong spiele den Song {Song} von dem Album {Album}
 ListenToSong spiele den Song {Song} von {Artist}
 Menu öffne Menü

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -448,12 +448,16 @@ ListenToLatestAlbum spiele neuestes Album von {Artist}
 ListenToLatestAlbum spiele zuletzt das hinzugefügte Album von {Artist}
 ListenToLatestAlbum spiele zuletzt hinzugefügtes Album von {Artist}
 ListenToSong spiel das Lied {Song}
+ListenToSong spiel das Lied {Song} von dem Album {Album}
 ListenToSong spiel das Lied {Song} von {Artist}
 ListenToSong spiel den Song {Song}
+ListenToSong spiel den Song {Song} von dem Album {Album}
 ListenToSong spiel den Song {Song} von {Artist}
 ListenToSong spiele das Lied {Song}
+ListenToSong spiele das Lied {Song} von dem Album {Album}
 ListenToSong spiele das Lied {Song} von {Artist}
 ListenToSong spiele den Song {Song}
+ListenToSong spiele den Song {Song} von dem Album {Album}
 ListenToSong spiele den Song {Song} von {Artist}
 Menu öffne Menü
 Mute ton an

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -199,12 +199,28 @@ ListenToLatestAlbum play the latest album by {Artist}
 ListenToLatestAlbum play the newest album by {Artist}
 ListenToSong listen to song {Song}
 ListenToSong listen to song {Song} by {Artist}
+ListenToSong listen to song {Song} from album {Album}
+ListenToSong listen to song {Song} from the album {Album}
+ListenToSong listen to song {Song} on album {Album}
+ListenToSong listen to song {Song} on the album {Album}
 ListenToSong listen to the song {Song}
 ListenToSong listen to the song {Song} by {Artist}
+ListenToSong listen to the song {Song} from album {Album}
+ListenToSong listen to the song {Song} from the album {Album}
+ListenToSong listen to the song {Song} on album {Album}
+ListenToSong listen to the song {Song} on the album {Album}
 ListenToSong play song {Song}
 ListenToSong play song {Song} by {Artist}
+ListenToSong play song {Song} from album {Album}
+ListenToSong play song {Song} from the album {Album}
+ListenToSong play song {Song} on album {Album}
+ListenToSong play song {Song} on the album {Album}
 ListenToSong play the song {Song}
 ListenToSong play the song {Song} by {Artist}
+ListenToSong play the song {Song} from album {Album}
+ListenToSong play the song {Song} from the album {Album}
+ListenToSong play the song {Song} on album {Album}
+ListenToSong play the song {Song} on the album {Album}
 Menu open menu
 Mute mute
 Mute set mute

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -18,6 +18,8 @@ could_not_find_song: "Konnte den Song {{ song_name }} nicht finden"
 
 could_not_find_song_artist: "Konnte den Song {{ song_name }} von {{ artist }} nicht finden"
 
++could_not_find_song_album: "Konnte den Song {{ song_name }} von dem Album {{ album_name }} nicht finden"
+
 could_not_find_multi: "Konnte {{ heard_name }} von {{ artist }} nicht finden"
 
 could_not_find_playlist: "Konnte die Playlist {{ heard_name }} nicht finden"
@@ -61,6 +63,8 @@ playing_album_artist: "Spiele das Album {{ album_name }} von {{ artist }}"
 playing_song: "Spiele den Song {{ song_name }}"
 
 playing_song_artist: "Spiele den Song {{ song_name }} von {{ artist }}"
+
+playing_song_album: "Spiele den Song {{ song_name }} von dem Album {{ album_name }}"
 
 playing_playlist_audio: "{{ action }} Audio Playlist {{ playlist_name }}"
 

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -18,7 +18,7 @@ could_not_find_song: "Konnte den Song {{ song_name }} nicht finden"
 
 could_not_find_song_artist: "Konnte den Song {{ song_name }} von {{ artist }} nicht finden"
 
-+could_not_find_song_album: "Konnte den Song {{ song_name }} von dem Album {{ album_name }} nicht finden"
+could_not_find_song_album: "Konnte den Song {{ song_name }} von dem Album {{ album_name }} nicht finden"
 
 could_not_find_multi: "Konnte {{ heard_name }} von {{ artist }} nicht finden"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -18,6 +18,8 @@ could_not_find_song: "Could not find the song {{ song_name }}"
 
 could_not_find_song_artist: "Could not find the song {{ song_name }} by {{ artist }}"
 
+could_not_find_song_album: "Could not find the song {{ song_name }} on the album {{ album_name }}"
+
 could_not_find_multi: "Could not find {{ heard_name }} by {{ artist }}"
 
 could_not_find_playlist: "I could not find a playlist named {{ heard_name }}"
@@ -61,6 +63,8 @@ playing_album_artist: "Playing album {{ album_name }} by {{ artist }}"
 playing_song: "Playing the song {{ song_name }}"
 
 playing_song_artist: "Playing the song {{ song_name }} by {{ artist }}"
+
+playing_song_album: "Playing the song {{ song_name }} on the album {{ album_name }}"
 
 playing_playlist_audio: "{{ action }} the audio playlist {{ playlist_name }}"
 

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -87,6 +87,7 @@ ListenToAlbum spiel(/e) (das Album/die CD/die Platte) {Album} (/von {Artist})
 
 ListenToSong spiel(/e) (das Lied/den Song) {Song}
 ListenToSong spiel(/e) (das Lied/den Song) {Song} von {Artist}
+ListenToSong spiel(/e) (das Lied/den Song) {Song} von dem Album {Album}
 
 ListenToAlbumOrSong spiel(/e) (/das Album/die CD/die Platte) {Album} von (/der Band/der Gruppe) {Artist}
 ListenToAlbumOrSong spiel(/e) (/das Lied/den Song) {Song} von {Artist}

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -87,7 +87,7 @@ ListenToAlbum spiel(/e) (das Album/die CD/die Platte) {Album} (/von {Artist})
 
 ListenToSong spiel(/e) (das Lied/den Song) {Song}
 ListenToSong spiel(/e) (das Lied/den Song) {Song} von {Artist}
-ListenToSong spiel(/e) (das Lied/den Song) {Song} von dem Album {Album}
+ListenToSong spiel(/e) (das Lied/den Song) {Song} (auf dem/von dem/vom/aus dem) Album {Album}
 
 ListenToAlbumOrSong spiel(/e) (/das Album/die CD/die Platte) {Album} von (/der Band/der Gruppe) {Artist}
 ListenToAlbumOrSong spiel(/e) (/das Lied/den Song) {Song} von {Artist}

--- a/utterances.txt
+++ b/utterances.txt
@@ -89,6 +89,7 @@ ListenToAlbum (play/listen to) (/the) album {Album} by {Artist}
 
 ListenToSong (play/listen to) (/the) song {Song}
 ListenToSong (play/listen to) (/the) song {Song} by {Artist}
+ListenToSong (play/listen to) (/the) song {Song} (from/on) (/the) album {Album}
 
 ListenToAlbumOrSong (play/listen to) {Album} by {Artist}
 ListenToAlbumOrSong (play/listen to) {Song} by {Artist}


### PR DESCRIPTION
Example, 'play the song creep on the album pablo honey'.

The qualifiers `song` and `album` were unfortunately both required to prevent collisions with other utterances.