### PR TITLE
Update README for 'packaging' module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,16 @@ After you've done that, run `pip install virtualenv`. This is required for a lat
 Now, clone my repo: `git clone https://github.com/m0ngr31/kodi-alexa.git` and `cd kodi-alexa`. Once you are inside the project directory, you're going to create a new "Virtual environement" and then activate it:
 `virtualenv venv` and `source venv/bin/activate` (if you are on Windows, that's `venv\Scripts\activate.bat` or `venv\Scripts\activate.ps1` for Powershell).
 
-After successful completion, run `pip install -r requirements.txt` and `pip install zappa`. Before you deploy, you need to create the file `kodi.config` from the [kodi.config.example template](https://raw.githubusercontent.com/m0ngr31/kodi-voice/master/kodi_voice/kodi.config.example) and enter the correct information for: address, port, username, and password. I'll go over the other variables in another section below.
+After successful completion, run `pip install -r requirements.txt`, `pip install packaging`, and `pip install zappa`.
 
-Before you can send any code to Lambda, you'll need to setup Zappa. Just run `zappa init` and accept the defaults for everything. If it doesn't automatically detect that this is a Flask app, tell it that the application function is "alexa.app".
+Before you deploy, you need to create the file `kodi.config` from the [kodi.config.example template](https://raw.githubusercontent.com/m0ngr31/kodi-voice/master/kodi_voice/kodi.config.example) and enter the correct information for: address, port, username, and password. I'll go over the other variables in another section below.
+
+Before you can send any code to Lambda, you'll need to set up Zappa. Just run `zappa init` and accept the defaults for everything. If it doesn't automatically detect that this is a Flask app, tell it that the application function is `alexa.app`.
 
 To make an initial deployment to Lambda, just run the following command: `zappa deploy dev`. It'll take a few minutes, and at the end it will give you a URL that you will need to copy. It will look like this:
 ![Lambda deploy](http://i.imgur.com/5rtN5ls.png)
 
-You are now running on Lambda! To update after there is a change here, or you updated your env variables, just run `zappa update dev`.
+You are now running on Lambda! To update after there is a change here, or you updated your env variables, see the instructions in UPGRADING.md.
 
 Now skip ahead to the [Skill setup section](#skill-setup).
 


### PR DESCRIPTION
Something used to require it and doesn't any more, but it's still needed for successful AWS deployment.  Added instructions to manually install it for now.