### PR TITLE
Add WatchMovieTrailer Intent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Here are some of the features supported by this skill:
 - Play random unwatched episode of TV show
 - Play random unwatched movie
 - Play random movie from a specific genre
-- Play specific episode of a TV show ('Play season 4 episode 10 of The Office')
 - Play specific movie
+- Play trailer for a movie in your library (*requires plugin.video.youtube addon*)
+- Play specific episode of a TV show ('Play season 4 episode 10 of The Office')
 - Continue watching next episode of last show that was watched
 - Play next episode of a show
 - Play newest episode of a show

--- a/alexa.py
+++ b/alexa.py
@@ -1766,6 +1766,27 @@ def alexa_watch_movie(Movie):
   return statement(response_text).simple_card(card_title, response_text)
 
 
+# Handle the WatchMovieTrailer intent.
+@ask.intent('WatchMovieTrailer')
+def alexa_watch_movie_trailer(Movie):
+  card_title = render_template('playing_movie_trailer').encode("utf-8")
+  print card_title
+
+  kodi = Kodi(config, context)
+  movie = kodi.FindMovie(Movie)
+  if len(movie) > 0:
+    movie_details = kodi.GetMovieDetails(movie[0][0])
+    if 'trailer' in movie_details and movie_details['trailer']:
+      kodi.PlayFile(movie_details['trailer'])
+      response_text = render_template('playing_trailer', heard_name=movie[0][1]).encode("utf-8")
+    else:
+      response_text = render_template('could_not_find_trailer', heard_name=Movie).encode("utf-8")
+  else:
+    response_text = render_template('could_not_find_movie', heard_movie=Movie).encode("utf-8")
+
+  return statement(response_text).simple_card(card_title, response_text)
+
+
 # Handle the ShuffleShow intent.
 @ask.intent('ShuffleShow')
 def alexa_shuffle_show(Show):

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -357,6 +357,15 @@
       ]
     },
     {
+      "intent": "WatchMovieTrailer",
+      "slots": [
+        {
+          "name": "Movie",
+          "type": "MOVIES"
+        }
+      ]
+    },
+    {
       "intent": "WatchVideoPlaylist",
       "slots": [
         {

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -1020,6 +1020,14 @@ WatchLatestEpisode zeige letzte Folge von {Show}
 WatchLatestEpisode zeige neueste Episode von {Show}
 WatchLatestEpisode zeige neueste Folge von {Show}
 WatchMovie zeige Film {Movie}
+WatchMovieTrailer spiele Trailer für {Movie}
+WatchMovieTrailer spiele Trailer von {Movie}
+WatchMovieTrailer spiele Vorschau für {Movie}
+WatchMovieTrailer spiele Vorschau von {Movie}
+WatchMovieTrailer zeige Trailer für {Movie}
+WatchMovieTrailer zeige Trailer von {Movie}
+WatchMovieTrailer zeige Vorschau für {Movie}
+WatchMovieTrailer zeige Vorschau von {Movie}
 WatchNextEpisode zeige nächste Episode von {Show}
 WatchNextEpisode zeige nächste Folge von {Show}
 WatchRandomEpisode zeige eine Episode von {Show}

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -651,6 +651,14 @@ WatchMovie watch film {Movie}
 WatchMovie watch movie {Movie}
 WatchMovie watch the film {Movie}
 WatchMovie watch the movie {Movie}
+WatchMovieTrailer play preview for {Movie}
+WatchMovieTrailer play the preview for {Movie}
+WatchMovieTrailer play the trailer for {Movie}
+WatchMovieTrailer play trailer for {Movie}
+WatchMovieTrailer watch preview for {Movie}
+WatchMovieTrailer watch the preview for {Movie}
+WatchMovieTrailer watch the trailer for {Movie}
+WatchMovieTrailer watch trailer for {Movie}
 WatchNextEpisode play next episode of {Show}
 WatchNextEpisode play the next episode of {Show}
 WatchNextEpisode watch next episode of {Show}

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -28,6 +28,8 @@ could_not_find_addon: "Konnte das Addon {{ heard_addon }} nicht finden"
 
 could_not_find_movie: "Konnte den Film {{ heard_movie }} nicht finden"
 
+could_not_find_trailer: "Konnte von {{ heard_name }} keinen Trailer finden."
+
 could_not_find_show: "Konnte die Serie {{ heard_show }} nicht finden"
 
 could_not_find_episode_show: "Konnte Staffel {{ season }} Folge {{ episode }} von {{ show_name }} nicht finden"
@@ -75,6 +77,8 @@ playing_party: "Starte Party Play"
 playing_genre: "Spiele den {{ genre }} Film {{ movie_name }}"
 
 playing_action: "{{ action }} {{ movie_name }}"
+
+playing_trailer: "Spiele Trailer von {{ heard_name }}"
 
 playing_episode_number: "Spiele die Staffel {{ season }} Folge {{ episode }} von {{ show_name }}"
 
@@ -284,6 +288,8 @@ playing_random_movie: "Spiele zufälligen Film"
 playing_random_movie_genre: "Spiele zufälligen {{ genre }} Film"
 
 playing_movie: "Spiele Film"
+
+playing_movie_trailer: "Spiele Filmtrailer"
 
 shuffling_episodes: "Spiele eine zufällige Folge von {{ heard_show }}"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -28,6 +28,8 @@ could_not_find_addon: "Could not find an addon called {{ heard_addon }}"
 
 could_not_find_movie: "Could not find a movie called {{ heard_movie }}"
 
+could_not_find_trailer: "Could not find a trailer for {{ heard_name }}"
+
 could_not_find_show: "Could not find a show named {{ heard_show }}"
 
 could_not_find_episode_show: "Could not find season {{ season }} episode {{ episode }} of {{ show_name }}"
@@ -75,6 +77,8 @@ playing_party: "Starting party play"
 playing_genre: "Playing the {{ genre }} movie {{ movie_name }}"
 
 playing_action: "{{ action }} {{ movie_name }}"
+
+playing_trailer: "Playing trailer for {{ heard_name }}"
 
 playing_episode_number: "Playing season {{ season }} episode {{ episode }} of {{ show_name }}"
 
@@ -283,7 +287,9 @@ playing_random_movie: "Playing a random movie"
 
 playing_random_movie_genre: "Playing a random {{ genre }} movie"
 
-playing_movie: "Playing Movie"
+playing_movie: "Playing movie"
+
+playing_movie_trailer: "Playing movie trailer"
 
 shuffling_episodes: "Shuffling episodes of {{ heard_show }}"
 

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -108,6 +108,8 @@ WatchRandomMovie zeige (/zufälligen) (/{Genre}) Film
 
 WatchMovie zeige Film {Movie}
 
+WatchMovieTrailer (spiele/zeige) (Trailer/Vorschau) (von/für) {Movie}
+
 WatchEpisode zeige Staffel {Season} (Episode/Folge) {Episode} von {Show}
 
 WatchRandomEpisode zeige eine (/zufällige) (Episode/Folge) von {Show}

--- a/utterances.txt
+++ b/utterances.txt
@@ -114,6 +114,8 @@ WatchRandomMovie (play/watch) (/a) random (/{Genre}) (movie/film)
 
 WatchMovie (play/watch) (/the) (movie/film) {Movie}
 
+WatchMovieTrailer (play/watch) (/the) (trailer/preview) for {Movie}
+
 WatchEpisode (play/watch) (season/series) {Season} episode {Episode} of {Show}
 
 WatchRandomEpisode (play/watch) (/random) episode of {Show}


### PR DESCRIPTION
Only works for movies in the user's library and requires YouTube addon.

I've added this to further expand the way to explore the library via conversation with Alexa.  This PR simply adds the ability to play trailers, but the idea is that combined with other recent changes, the user can have an on-going conversation with Alexa to decide what to watch:

```
Alexa, open Kodi
Go to movies
Show more
Watch trailer for (some movie on the screen)
Alexa, tell Kodi to watch (the movie)
```

Or:

```
Alexa, ask Kodi to recommend a movie
Play the preview for (the movie she suggested)
```

Or:

```
Alexa, ask Kodi what new movies we have
Alexa, ask Kodi to play trailer for (something on the list she gave)
```