### PR TITLE
Add support for music genres.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,14 @@ The initial setup page looks like this:
 
 On the next page, you'll have to paste the contents of the [IntentSchema.json](https://raw.githubusercontent.com/m0ngr31/kodi-alexa/master/speech_assets/IntentSchema.json) file into the "Intent Schema" field, and paste the contents of the [SampleUtterances.txt](https://raw.githubusercontent.com/m0ngr31/kodi-alexa/master/speech_assets/SampleUtterances.txt) or [SampleUtterances.german.txt](https://raw.githubusercontent.com/m0ngr31/kodi-alexa/master/speech_assets/SampleUtterances.german.txt) file in the "Sample Utterances" field. **Generate and save your Custom Slots first before pasting the Intents and Utterances to avoid errors when attempting to save**.
 
-You need to create 9 different slots:
+You need to create the following slots:
 - MOVIES
 - MOVIEGENRES
 - SHOWS
 - MUSICARTISTS
 - MUSICALBUMS
 - MUSICSONGS
+- MUSICGENRES
 - MUSICPLAYLISTS
 - VIDEOPLAYLISTS
 - ADDONS

--- a/generate_custom_slots.py
+++ b/generate_custom_slots.py
@@ -91,6 +91,12 @@ cl = clean_results(retrieved, 'files', 'label')
 write_file('MUSICPLAYLISTS', cl)
 
 
+# Generate MUSICGENRES Slot
+retrieved = kodi.GetMusicGenres()
+cl = clean_results(retrieved, 'genres', 'label')
+write_file('MUSICGENRES', cl)
+
+
 # Generate MUSICARTISTS Slot
 retrieved = kodi.GetMusicArtists()
 cl = clean_results(retrieved, 'artists', 'artist')

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -37,7 +37,7 @@
       "intent": "WhatNewMovies",
       "slots": [
         {
-          "name": "Genre",
+          "name": "MovieGenre",
           "type": "MOVIEGENRES"
         }
       ]
@@ -175,11 +175,24 @@
       ]
     },
     {
+      "intent": "ListenToGenre",
+      "slots": [
+        {
+          "name": "MusicGenre",
+          "type": "MUSICGENRES"
+        }
+      ]
+    },
+    {
       "intent": "ListenToArtist",
       "slots": [
         {
           "name": "Artist",
           "type": "MUSICARTISTS"
+        },
+        {
+          "name": "MusicGenre",
+          "type": "MUSICGENRES"
         }
       ]
     },
@@ -347,7 +360,7 @@
       "intent": "WatchRandomMovie",
       "slots": [
         {
-          "name": "Genre",
+          "name": "MovieGenre",
           "type": "MOVIEGENRES"
         }
       ]

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -306,78 +306,78 @@ ListenToAlbum spiele die Platte {Album}
 ListenToAlbum spiele die Platte {Album} von {Artist}
 ListenToAlbumOrSong spiel {Song} von {Artist}
 ListenToAlbumOrSong spiele {Song} von {Artist}
-ListenToArtist spiel Lieder von dem Artist {Artist}
-ListenToArtist spiel Lieder von dem Komponist {Artist}
-ListenToArtist spiel Lieder von dem Künstler {Artist}
-ListenToArtist spiel Lieder von der Artistin {Artist}
-ListenToArtist spiel Lieder von der Band {Artist}
-ListenToArtist spiel Lieder von der Gruppe {Artist}
-ListenToArtist spiel Lieder von der Komponistin {Artist}
-ListenToArtist spiel Lieder von der Künstlerin {Artist}
-ListenToArtist spiel Lieder von {Artist}
-ListenToArtist spiel Mucke von dem Artist {Artist}
-ListenToArtist spiel Mucke von dem Komponist {Artist}
-ListenToArtist spiel Mucke von dem Künstler {Artist}
-ListenToArtist spiel Mucke von der Artistin {Artist}
-ListenToArtist spiel Mucke von der Band {Artist}
-ListenToArtist spiel Mucke von der Gruppe {Artist}
-ListenToArtist spiel Mucke von der Komponistin {Artist}
-ListenToArtist spiel Mucke von der Künstlerin {Artist}
-ListenToArtist spiel Mucke von {Artist}
 ListenToArtist spiel Musik von dem Artist {Artist}
-ListenToArtist spiel Musik von dem Komponist {Artist}
+ListenToArtist spiel Musik von dem Interpreten {Artist}
+ListenToArtist spiel Musik von dem Komponisten {Artist}
 ListenToArtist spiel Musik von dem Künstler {Artist}
-ListenToArtist spiel Musik von der Artistin {Artist}
 ListenToArtist spiel Musik von der Band {Artist}
 ListenToArtist spiel Musik von der Gruppe {Artist}
 ListenToArtist spiel Musik von der Komponistin {Artist}
 ListenToArtist spiel Musik von der Künstlerin {Artist}
 ListenToArtist spiel Musik von {Artist}
 ListenToArtist spiel Songs von dem Artist {Artist}
-ListenToArtist spiel Songs von dem Komponist {Artist}
+ListenToArtist spiel Songs von dem Interpreten {Artist}
+ListenToArtist spiel Songs von dem Komponisten {Artist}
 ListenToArtist spiel Songs von dem Künstler {Artist}
-ListenToArtist spiel Songs von der Artistin {Artist}
 ListenToArtist spiel Songs von der Band {Artist}
 ListenToArtist spiel Songs von der Gruppe {Artist}
 ListenToArtist spiel Songs von der Komponistin {Artist}
 ListenToArtist spiel Songs von der Künstlerin {Artist}
 ListenToArtist spiel Songs von {Artist}
-ListenToArtist spiele Lieder von dem Artist {Artist}
-ListenToArtist spiele Lieder von dem Komponist {Artist}
-ListenToArtist spiele Lieder von dem Künstler {Artist}
-ListenToArtist spiele Lieder von der Artistin {Artist}
-ListenToArtist spiele Lieder von der Band {Artist}
-ListenToArtist spiele Lieder von der Gruppe {Artist}
-ListenToArtist spiele Lieder von der Komponistin {Artist}
-ListenToArtist spiele Lieder von der Künstlerin {Artist}
-ListenToArtist spiele Lieder von {Artist}
-ListenToArtist spiele Mucke von dem Artist {Artist}
-ListenToArtist spiele Mucke von dem Komponist {Artist}
-ListenToArtist spiele Mucke von dem Künstler {Artist}
-ListenToArtist spiele Mucke von der Artistin {Artist}
-ListenToArtist spiele Mucke von der Band {Artist}
-ListenToArtist spiele Mucke von der Gruppe {Artist}
-ListenToArtist spiele Mucke von der Komponistin {Artist}
-ListenToArtist spiele Mucke von der Künstlerin {Artist}
-ListenToArtist spiele Mucke von {Artist}
+ListenToArtist spiel {MusicGenre} Musik von dem Artist {Artist}
+ListenToArtist spiel {MusicGenre} Musik von dem Interpreten {Artist}
+ListenToArtist spiel {MusicGenre} Musik von dem Komponisten {Artist}
+ListenToArtist spiel {MusicGenre} Musik von dem Künstler {Artist}
+ListenToArtist spiel {MusicGenre} Musik von der Band {Artist}
+ListenToArtist spiel {MusicGenre} Musik von der Gruppe {Artist}
+ListenToArtist spiel {MusicGenre} Musik von der Komponistin {Artist}
+ListenToArtist spiel {MusicGenre} Musik von der Künstlerin {Artist}
+ListenToArtist spiel {MusicGenre} Musik von {Artist}
+ListenToArtist spiel {MusicGenre} Songs von dem Artist {Artist}
+ListenToArtist spiel {MusicGenre} Songs von dem Interpreten {Artist}
+ListenToArtist spiel {MusicGenre} Songs von dem Komponisten {Artist}
+ListenToArtist spiel {MusicGenre} Songs von dem Künstler {Artist}
+ListenToArtist spiel {MusicGenre} Songs von der Band {Artist}
+ListenToArtist spiel {MusicGenre} Songs von der Gruppe {Artist}
+ListenToArtist spiel {MusicGenre} Songs von der Komponistin {Artist}
+ListenToArtist spiel {MusicGenre} Songs von der Künstlerin {Artist}
+ListenToArtist spiel {MusicGenre} Songs von {Artist}
 ListenToArtist spiele Musik von dem Artist {Artist}
-ListenToArtist spiele Musik von dem Komponist {Artist}
+ListenToArtist spiele Musik von dem Interpreten {Artist}
+ListenToArtist spiele Musik von dem Komponisten {Artist}
 ListenToArtist spiele Musik von dem Künstler {Artist}
-ListenToArtist spiele Musik von der Artistin {Artist}
 ListenToArtist spiele Musik von der Band {Artist}
 ListenToArtist spiele Musik von der Gruppe {Artist}
 ListenToArtist spiele Musik von der Komponistin {Artist}
 ListenToArtist spiele Musik von der Künstlerin {Artist}
 ListenToArtist spiele Musik von {Artist}
 ListenToArtist spiele Songs von dem Artist {Artist}
-ListenToArtist spiele Songs von dem Komponist {Artist}
+ListenToArtist spiele Songs von dem Interpreten {Artist}
+ListenToArtist spiele Songs von dem Komponisten {Artist}
 ListenToArtist spiele Songs von dem Künstler {Artist}
-ListenToArtist spiele Songs von der Artistin {Artist}
 ListenToArtist spiele Songs von der Band {Artist}
 ListenToArtist spiele Songs von der Gruppe {Artist}
 ListenToArtist spiele Songs von der Komponistin {Artist}
 ListenToArtist spiele Songs von der Künstlerin {Artist}
 ListenToArtist spiele Songs von {Artist}
+ListenToArtist spiele {MusicGenre} Musik von dem Artist {Artist}
+ListenToArtist spiele {MusicGenre} Musik von dem Interpreten {Artist}
+ListenToArtist spiele {MusicGenre} Musik von dem Komponisten {Artist}
+ListenToArtist spiele {MusicGenre} Musik von dem Künstler {Artist}
+ListenToArtist spiele {MusicGenre} Musik von der Band {Artist}
+ListenToArtist spiele {MusicGenre} Musik von der Gruppe {Artist}
+ListenToArtist spiele {MusicGenre} Musik von der Komponistin {Artist}
+ListenToArtist spiele {MusicGenre} Musik von der Künstlerin {Artist}
+ListenToArtist spiele {MusicGenre} Musik von {Artist}
+ListenToArtist spiele {MusicGenre} Songs von dem Artist {Artist}
+ListenToArtist spiele {MusicGenre} Songs von dem Interpreten {Artist}
+ListenToArtist spiele {MusicGenre} Songs von dem Komponisten {Artist}
+ListenToArtist spiele {MusicGenre} Songs von dem Künstler {Artist}
+ListenToArtist spiele {MusicGenre} Songs von der Band {Artist}
+ListenToArtist spiele {MusicGenre} Songs von der Gruppe {Artist}
+ListenToArtist spiele {MusicGenre} Songs von der Komponistin {Artist}
+ListenToArtist spiele {MusicGenre} Songs von der Künstlerin {Artist}
+ListenToArtist spiele {MusicGenre} Songs von {Artist}
 ListenToAudio {Artist} anhören
 ListenToAudioPlaylist spiel Lieder playlist {AudioPlaylist}
 ListenToAudioPlaylist spiel Musik playlist {AudioPlaylist}
@@ -409,6 +409,12 @@ ListenToAudioPlaylistRecent spiele neue Songs
 ListenToAudioPlaylistRecent spiele zuletzt hinzugefügte Lieder
 ListenToAudioPlaylistRecent spiele zuletzt hinzugefügte Musik
 ListenToAudioPlaylistRecent spiele zuletzt hinzugefügte Songs
+ListenToGenre spiel {MusicGenre} Genre
+ListenToGenre spiel {MusicGenre} Musik
+ListenToGenre spiel {MusicGenre} Songs
+ListenToGenre spiele {MusicGenre} Genre
+ListenToGenre spiele {MusicGenre} Musik
+ListenToGenre spiele {MusicGenre} Songs
 ListenToLatestAlbum spiele aktuelles Album von {Artist}
 ListenToLatestAlbum spiele aktuellstes Album von {Artist}
 ListenToLatestAlbum spiele das aktuelle Album von {Artist}
@@ -1012,8 +1018,8 @@ WatchRandomEpisode zeige eine zufällige Episode von {Show}
 WatchRandomEpisode zeige eine zufällige Folge von {Show}
 WatchRandomMovie zeige Film
 WatchRandomMovie zeige zufälligen Film
-WatchRandomMovie zeige zufälligen {Genre} Film
-WatchRandomMovie zeige {Genre} Film
+WatchRandomMovie zeige zufälligen {MovieGenre} Film
+WatchRandomMovie zeige {MovieGenre} Film
 WatchVideo zeige {Movie}
 WatchVideoPlaylist zeige Film playlist {VideoPlaylist}
 WatchVideoPlaylist zeige Serie playlist {VideoPlaylist}
@@ -1084,37 +1090,37 @@ WhatNewEpisodes ob wir neue Folgen {Show} haben
 WhatNewEpisodes ob wir neue von {Show} haben
 WhatNewEpisodes ob wir neue {Show} haben
 WhatNewMovies ob es einen neuen Film gibt
-WhatNewMovies ob es einen neuen {Genre} Film gibt
+WhatNewMovies ob es einen neuen {MovieGenre} Film gibt
 WhatNewMovies ob es neue Filme gibt
-WhatNewMovies ob es neue {Genre} Filme gibt
+WhatNewMovies ob es neue {MovieGenre} Filme gibt
 WhatNewMovies ob wir einen neuen Film haben
-WhatNewMovies ob wir einen neuen {Genre} Film haben
+WhatNewMovies ob wir einen neuen {MovieGenre} Film haben
 WhatNewMovies ob wir neue Filme haben
-WhatNewMovies ob wir neue {Genre} Filme haben
+WhatNewMovies ob wir neue {MovieGenre} Filme haben
 WhatNewMovies welche Filme aufgenommen worden sind
 WhatNewMovies welche Filme fertig sind
 WhatNewMovies welche Filme warten
 WhatNewMovies welche neuen Filme aufgenommen worden sind
 WhatNewMovies welche neuen Filme fertig sind
 WhatNewMovies welche neuen Filme warten
-WhatNewMovies welche neuen {Genre} Filme aufgenommen worden sind
-WhatNewMovies welche neuen {Genre} Filme fertig sind
-WhatNewMovies welche neuen {Genre} Filme warten
-WhatNewMovies welche {Genre} Filme aufgenommen worden sind
-WhatNewMovies welche {Genre} Filme fertig sind
-WhatNewMovies welche {Genre} Filme warten
+WhatNewMovies welche neuen {MovieGenre} Filme aufgenommen worden sind
+WhatNewMovies welche neuen {MovieGenre} Filme fertig sind
+WhatNewMovies welche neuen {MovieGenre} Filme warten
+WhatNewMovies welche {MovieGenre} Filme aufgenommen worden sind
+WhatNewMovies welche {MovieGenre} Filme fertig sind
+WhatNewMovies welche {MovieGenre} Filme warten
 WhatNewMovies welcher Film aufgenommen worden ist
 WhatNewMovies welcher Film fertig ist
 WhatNewMovies welcher Film wartet
 WhatNewMovies welcher neue Film aufgenommen worden ist
 WhatNewMovies welcher neue Film fertig ist
 WhatNewMovies welcher neue Film wartet
-WhatNewMovies welcher neue {Genre} Film aufgenommen worden ist
-WhatNewMovies welcher neue {Genre} Film fertig ist
-WhatNewMovies welcher neue {Genre} Film wartet
-WhatNewMovies welcher {Genre} Film aufgenommen worden ist
-WhatNewMovies welcher {Genre} Film fertig ist
-WhatNewMovies welcher {Genre} Film wartet
+WhatNewMovies welcher neue {MovieGenre} Film aufgenommen worden ist
+WhatNewMovies welcher neue {MovieGenre} Film fertig ist
+WhatNewMovies welcher neue {MovieGenre} Film wartet
+WhatNewMovies welcher {MovieGenre} Film aufgenommen worden ist
+WhatNewMovies welcher {MovieGenre} Film fertig ist
+WhatNewMovies welcher {MovieGenre} Film wartet
 WhatNewShows welche Serie aufgenommen worden ist
 WhatNewShows welche Serie fertig ist
 WhatNewShows welche Serie wartet

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -107,10 +107,16 @@ ListenToAlbumOrSong listen to {Song} by {Artist}
 ListenToAlbumOrSong play {Song} by {Artist}
 ListenToArtist listen to artist {Artist}
 ListenToArtist listen to music by {Artist}
+ListenToArtist listen to {MusicGenre} artist {Artist}
+ListenToArtist listen to {MusicGenre} music by {Artist}
 ListenToArtist play artist {Artist}
 ListenToArtist play music by {Artist}
+ListenToArtist play {MusicGenre} artist {Artist}
+ListenToArtist play {MusicGenre} music by {Artist}
 ListenToArtist shuffle artist {Artist}
 ListenToArtist shuffle music by {Artist}
+ListenToArtist shuffle {MusicGenre} artist {Artist}
+ListenToArtist shuffle {MusicGenre} music by {Artist}
 ListenToAudio listen to {Artist}
 ListenToAudioPlaylist listen to audio playlist {AudioPlaylist}
 ListenToAudioPlaylist listen to music playlist {AudioPlaylist}
@@ -187,6 +193,15 @@ ListenToAudioPlaylistRecent shuffle recently added albums
 ListenToAudioPlaylistRecent shuffle recently added audio
 ListenToAudioPlaylistRecent shuffle recently added music
 ListenToAudioPlaylistRecent shuffle recently added songs
+ListenToGenre listen to {MusicGenre} genre
+ListenToGenre listen to {MusicGenre} music
+ListenToGenre listen to {MusicGenre} songs
+ListenToGenre play {MusicGenre} genre
+ListenToGenre play {MusicGenre} music
+ListenToGenre play {MusicGenre} songs
+ListenToGenre shuffle {MusicGenre} genre
+ListenToGenre shuffle {MusicGenre} music
+ListenToGenre shuffle {MusicGenre} songs
 ListenToLatestAlbum listen to latest album by {Artist}
 ListenToLatestAlbum listen to newest album by {Artist}
 ListenToLatestAlbum listen to the latest album by {Artist}
@@ -675,20 +690,20 @@ WatchRandomEpisode watch episode of {Show}
 WatchRandomEpisode watch random episode of {Show}
 WatchRandomMovie play a random film
 WatchRandomMovie play a random movie
-WatchRandomMovie play a random {Genre} film
-WatchRandomMovie play a random {Genre} movie
+WatchRandomMovie play a random {MovieGenre} film
+WatchRandomMovie play a random {MovieGenre} movie
 WatchRandomMovie play random film
 WatchRandomMovie play random movie
-WatchRandomMovie play random {Genre} film
-WatchRandomMovie play random {Genre} movie
+WatchRandomMovie play random {MovieGenre} film
+WatchRandomMovie play random {MovieGenre} movie
 WatchRandomMovie watch a random film
 WatchRandomMovie watch a random movie
-WatchRandomMovie watch a random {Genre} film
-WatchRandomMovie watch a random {Genre} movie
+WatchRandomMovie watch a random {MovieGenre} film
+WatchRandomMovie watch a random {MovieGenre} movie
 WatchRandomMovie watch random film
 WatchRandomMovie watch random movie
-WatchRandomMovie watch random {Genre} film
-WatchRandomMovie watch random {Genre} movie
+WatchRandomMovie watch random {MovieGenre} film
+WatchRandomMovie watch random {MovieGenre} movie
 WatchVideo watch {Movie}
 WatchVideoPlaylist play movie playlist {VideoPlaylist}
 WatchVideoPlaylist play show playlist {VideoPlaylist}
@@ -741,414 +756,414 @@ WhatNewEpisodes if we have a new episode of {Show}
 WhatNewEpisodes if we have an episode of {Show}
 WhatNewEpisodes if we have any episodes of {Show}
 WhatNewEpisodes if we have any new episodes of {Show}
-WhatNewMovies are there any new {Genre} films
-WhatNewMovies are there any new {Genre} films recorded
-WhatNewMovies are there any new {Genre} films recorded to watch
-WhatNewMovies are there any new {Genre} films recorded to watch today
-WhatNewMovies are there any new {Genre} films recorded to watch tonight
-WhatNewMovies are there any new {Genre} films recorded today
-WhatNewMovies are there any new {Genre} films recorded tonight
-WhatNewMovies are there any new {Genre} films to watch
-WhatNewMovies are there any new {Genre} films to watch today
-WhatNewMovies are there any new {Genre} films to watch tonight
-WhatNewMovies are there any new {Genre} films today
-WhatNewMovies are there any new {Genre} films tonight
-WhatNewMovies are there any new {Genre} movies
-WhatNewMovies are there any new {Genre} movies recorded
-WhatNewMovies are there any new {Genre} movies recorded to watch
-WhatNewMovies are there any new {Genre} movies recorded to watch today
-WhatNewMovies are there any new {Genre} movies recorded to watch tonight
-WhatNewMovies are there any new {Genre} movies recorded today
-WhatNewMovies are there any new {Genre} movies recorded tonight
-WhatNewMovies are there any new {Genre} movies to watch
-WhatNewMovies are there any new {Genre} movies to watch today
-WhatNewMovies are there any new {Genre} movies to watch tonight
-WhatNewMovies are there any new {Genre} movies today
-WhatNewMovies are there any new {Genre} movies tonight
+WhatNewMovies are there any new {MovieGenre} films
+WhatNewMovies are there any new {MovieGenre} films recorded
+WhatNewMovies are there any new {MovieGenre} films recorded to watch
+WhatNewMovies are there any new {MovieGenre} films recorded to watch today
+WhatNewMovies are there any new {MovieGenre} films recorded to watch tonight
+WhatNewMovies are there any new {MovieGenre} films recorded today
+WhatNewMovies are there any new {MovieGenre} films recorded tonight
+WhatNewMovies are there any new {MovieGenre} films to watch
+WhatNewMovies are there any new {MovieGenre} films to watch today
+WhatNewMovies are there any new {MovieGenre} films to watch tonight
+WhatNewMovies are there any new {MovieGenre} films today
+WhatNewMovies are there any new {MovieGenre} films tonight
+WhatNewMovies are there any new {MovieGenre} movies
+WhatNewMovies are there any new {MovieGenre} movies recorded
+WhatNewMovies are there any new {MovieGenre} movies recorded to watch
+WhatNewMovies are there any new {MovieGenre} movies recorded to watch today
+WhatNewMovies are there any new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies are there any new {MovieGenre} movies recorded today
+WhatNewMovies are there any new {MovieGenre} movies recorded tonight
+WhatNewMovies are there any new {MovieGenre} movies to watch
+WhatNewMovies are there any new {MovieGenre} movies to watch today
+WhatNewMovies are there any new {MovieGenre} movies to watch tonight
+WhatNewMovies are there any new {MovieGenre} movies today
+WhatNewMovies are there any new {MovieGenre} movies tonight
 WhatNewMovies are there new films
 WhatNewMovies are there new films to watch
 WhatNewMovies are there new movies
 WhatNewMovies are there new movies to watch
-WhatNewMovies are there new {Genre} films
-WhatNewMovies are there new {Genre} films recorded
-WhatNewMovies are there new {Genre} films recorded to watch
-WhatNewMovies are there new {Genre} films recorded to watch today
-WhatNewMovies are there new {Genre} films recorded to watch tonight
-WhatNewMovies are there new {Genre} films recorded today
-WhatNewMovies are there new {Genre} films recorded tonight
-WhatNewMovies are there new {Genre} films to watch
-WhatNewMovies are there new {Genre} films to watch today
-WhatNewMovies are there new {Genre} films to watch tonight
-WhatNewMovies are there new {Genre} films today
-WhatNewMovies are there new {Genre} films tonight
-WhatNewMovies are there new {Genre} movies
-WhatNewMovies are there new {Genre} movies recorded
-WhatNewMovies are there new {Genre} movies recorded to watch
-WhatNewMovies are there new {Genre} movies recorded to watch today
-WhatNewMovies are there new {Genre} movies recorded to watch tonight
-WhatNewMovies are there new {Genre} movies recorded today
-WhatNewMovies are there new {Genre} movies recorded tonight
-WhatNewMovies are there new {Genre} movies to watch
-WhatNewMovies are there new {Genre} movies to watch today
-WhatNewMovies are there new {Genre} movies to watch tonight
-WhatNewMovies are there new {Genre} movies today
-WhatNewMovies are there new {Genre} movies tonight
-WhatNewMovies are there some new {Genre} films
-WhatNewMovies are there some new {Genre} films recorded
-WhatNewMovies are there some new {Genre} films recorded to watch
-WhatNewMovies are there some new {Genre} films recorded to watch today
-WhatNewMovies are there some new {Genre} films recorded to watch tonight
-WhatNewMovies are there some new {Genre} films recorded today
-WhatNewMovies are there some new {Genre} films recorded tonight
-WhatNewMovies are there some new {Genre} films to watch
-WhatNewMovies are there some new {Genre} films to watch today
-WhatNewMovies are there some new {Genre} films to watch tonight
-WhatNewMovies are there some new {Genre} films today
-WhatNewMovies are there some new {Genre} films tonight
-WhatNewMovies are there some new {Genre} movies
-WhatNewMovies are there some new {Genre} movies recorded
-WhatNewMovies are there some new {Genre} movies recorded to watch
-WhatNewMovies are there some new {Genre} movies recorded to watch today
-WhatNewMovies are there some new {Genre} movies recorded to watch tonight
-WhatNewMovies are there some new {Genre} movies recorded today
-WhatNewMovies are there some new {Genre} movies recorded tonight
-WhatNewMovies are there some new {Genre} movies to watch
-WhatNewMovies are there some new {Genre} movies to watch today
-WhatNewMovies are there some new {Genre} movies to watch tonight
-WhatNewMovies are there some new {Genre} movies today
-WhatNewMovies are there some new {Genre} movies tonight
+WhatNewMovies are there new {MovieGenre} films
+WhatNewMovies are there new {MovieGenre} films recorded
+WhatNewMovies are there new {MovieGenre} films recorded to watch
+WhatNewMovies are there new {MovieGenre} films recorded to watch today
+WhatNewMovies are there new {MovieGenre} films recorded to watch tonight
+WhatNewMovies are there new {MovieGenre} films recorded today
+WhatNewMovies are there new {MovieGenre} films recorded tonight
+WhatNewMovies are there new {MovieGenre} films to watch
+WhatNewMovies are there new {MovieGenre} films to watch today
+WhatNewMovies are there new {MovieGenre} films to watch tonight
+WhatNewMovies are there new {MovieGenre} films today
+WhatNewMovies are there new {MovieGenre} films tonight
+WhatNewMovies are there new {MovieGenre} movies
+WhatNewMovies are there new {MovieGenre} movies recorded
+WhatNewMovies are there new {MovieGenre} movies recorded to watch
+WhatNewMovies are there new {MovieGenre} movies recorded to watch today
+WhatNewMovies are there new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies are there new {MovieGenre} movies recorded today
+WhatNewMovies are there new {MovieGenre} movies recorded tonight
+WhatNewMovies are there new {MovieGenre} movies to watch
+WhatNewMovies are there new {MovieGenre} movies to watch today
+WhatNewMovies are there new {MovieGenre} movies to watch tonight
+WhatNewMovies are there new {MovieGenre} movies today
+WhatNewMovies are there new {MovieGenre} movies tonight
+WhatNewMovies are there some new {MovieGenre} films
+WhatNewMovies are there some new {MovieGenre} films recorded
+WhatNewMovies are there some new {MovieGenre} films recorded to watch
+WhatNewMovies are there some new {MovieGenre} films recorded to watch today
+WhatNewMovies are there some new {MovieGenre} films recorded to watch tonight
+WhatNewMovies are there some new {MovieGenre} films recorded today
+WhatNewMovies are there some new {MovieGenre} films recorded tonight
+WhatNewMovies are there some new {MovieGenre} films to watch
+WhatNewMovies are there some new {MovieGenre} films to watch today
+WhatNewMovies are there some new {MovieGenre} films to watch tonight
+WhatNewMovies are there some new {MovieGenre} films today
+WhatNewMovies are there some new {MovieGenre} films tonight
+WhatNewMovies are there some new {MovieGenre} movies
+WhatNewMovies are there some new {MovieGenre} movies recorded
+WhatNewMovies are there some new {MovieGenre} movies recorded to watch
+WhatNewMovies are there some new {MovieGenre} movies recorded to watch today
+WhatNewMovies are there some new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies are there some new {MovieGenre} movies recorded today
+WhatNewMovies are there some new {MovieGenre} movies recorded tonight
+WhatNewMovies are there some new {MovieGenre} movies to watch
+WhatNewMovies are there some new {MovieGenre} movies to watch today
+WhatNewMovies are there some new {MovieGenre} movies to watch tonight
+WhatNewMovies are there some new {MovieGenre} movies today
+WhatNewMovies are there some new {MovieGenre} movies tonight
 WhatNewMovies do i have a new film
 WhatNewMovies do i have a new film to watch
 WhatNewMovies do i have a new movie
 WhatNewMovies do i have a new movie to watch
-WhatNewMovies do i have a new {Genre} film
-WhatNewMovies do i have a new {Genre} film recorded
-WhatNewMovies do i have a new {Genre} film recorded to watch
-WhatNewMovies do i have a new {Genre} film recorded to watch today
-WhatNewMovies do i have a new {Genre} film recorded to watch tonight
-WhatNewMovies do i have a new {Genre} film recorded today
-WhatNewMovies do i have a new {Genre} film recorded tonight
-WhatNewMovies do i have a new {Genre} film to watch
-WhatNewMovies do i have a new {Genre} film to watch today
-WhatNewMovies do i have a new {Genre} film to watch tonight
-WhatNewMovies do i have a new {Genre} film today
-WhatNewMovies do i have a new {Genre} film tonight
-WhatNewMovies do i have a new {Genre} movie
-WhatNewMovies do i have a new {Genre} movie recorded
-WhatNewMovies do i have a new {Genre} movie recorded to watch
-WhatNewMovies do i have a new {Genre} movie recorded to watch today
-WhatNewMovies do i have a new {Genre} movie recorded to watch tonight
-WhatNewMovies do i have a new {Genre} movie recorded today
-WhatNewMovies do i have a new {Genre} movie recorded tonight
-WhatNewMovies do i have a new {Genre} movie to watch
-WhatNewMovies do i have a new {Genre} movie to watch today
-WhatNewMovies do i have a new {Genre} movie to watch tonight
-WhatNewMovies do i have a new {Genre} movie today
-WhatNewMovies do i have a new {Genre} movie tonight
-WhatNewMovies do i have any new {Genre} films
-WhatNewMovies do i have any new {Genre} films recorded
-WhatNewMovies do i have any new {Genre} films recorded to watch
-WhatNewMovies do i have any new {Genre} films recorded to watch today
-WhatNewMovies do i have any new {Genre} films recorded to watch tonight
-WhatNewMovies do i have any new {Genre} films recorded today
-WhatNewMovies do i have any new {Genre} films recorded tonight
-WhatNewMovies do i have any new {Genre} films to watch
-WhatNewMovies do i have any new {Genre} films to watch today
-WhatNewMovies do i have any new {Genre} films to watch tonight
-WhatNewMovies do i have any new {Genre} films today
-WhatNewMovies do i have any new {Genre} films tonight
-WhatNewMovies do i have any new {Genre} movies
-WhatNewMovies do i have any new {Genre} movies recorded
-WhatNewMovies do i have any new {Genre} movies recorded to watch
-WhatNewMovies do i have any new {Genre} movies recorded to watch today
-WhatNewMovies do i have any new {Genre} movies recorded to watch tonight
-WhatNewMovies do i have any new {Genre} movies recorded today
-WhatNewMovies do i have any new {Genre} movies recorded tonight
-WhatNewMovies do i have any new {Genre} movies to watch
-WhatNewMovies do i have any new {Genre} movies to watch today
-WhatNewMovies do i have any new {Genre} movies to watch tonight
-WhatNewMovies do i have any new {Genre} movies today
-WhatNewMovies do i have any new {Genre} movies tonight
+WhatNewMovies do i have a new {MovieGenre} film
+WhatNewMovies do i have a new {MovieGenre} film recorded
+WhatNewMovies do i have a new {MovieGenre} film recorded to watch
+WhatNewMovies do i have a new {MovieGenre} film recorded to watch today
+WhatNewMovies do i have a new {MovieGenre} film recorded to watch tonight
+WhatNewMovies do i have a new {MovieGenre} film recorded today
+WhatNewMovies do i have a new {MovieGenre} film recorded tonight
+WhatNewMovies do i have a new {MovieGenre} film to watch
+WhatNewMovies do i have a new {MovieGenre} film to watch today
+WhatNewMovies do i have a new {MovieGenre} film to watch tonight
+WhatNewMovies do i have a new {MovieGenre} film today
+WhatNewMovies do i have a new {MovieGenre} film tonight
+WhatNewMovies do i have a new {MovieGenre} movie
+WhatNewMovies do i have a new {MovieGenre} movie recorded
+WhatNewMovies do i have a new {MovieGenre} movie recorded to watch
+WhatNewMovies do i have a new {MovieGenre} movie recorded to watch today
+WhatNewMovies do i have a new {MovieGenre} movie recorded to watch tonight
+WhatNewMovies do i have a new {MovieGenre} movie recorded today
+WhatNewMovies do i have a new {MovieGenre} movie recorded tonight
+WhatNewMovies do i have a new {MovieGenre} movie to watch
+WhatNewMovies do i have a new {MovieGenre} movie to watch today
+WhatNewMovies do i have a new {MovieGenre} movie to watch tonight
+WhatNewMovies do i have a new {MovieGenre} movie today
+WhatNewMovies do i have a new {MovieGenre} movie tonight
+WhatNewMovies do i have any new {MovieGenre} films
+WhatNewMovies do i have any new {MovieGenre} films recorded
+WhatNewMovies do i have any new {MovieGenre} films recorded to watch
+WhatNewMovies do i have any new {MovieGenre} films recorded to watch today
+WhatNewMovies do i have any new {MovieGenre} films recorded to watch tonight
+WhatNewMovies do i have any new {MovieGenre} films recorded today
+WhatNewMovies do i have any new {MovieGenre} films recorded tonight
+WhatNewMovies do i have any new {MovieGenre} films to watch
+WhatNewMovies do i have any new {MovieGenre} films to watch today
+WhatNewMovies do i have any new {MovieGenre} films to watch tonight
+WhatNewMovies do i have any new {MovieGenre} films today
+WhatNewMovies do i have any new {MovieGenre} films tonight
+WhatNewMovies do i have any new {MovieGenre} movies
+WhatNewMovies do i have any new {MovieGenre} movies recorded
+WhatNewMovies do i have any new {MovieGenre} movies recorded to watch
+WhatNewMovies do i have any new {MovieGenre} movies recorded to watch today
+WhatNewMovies do i have any new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies do i have any new {MovieGenre} movies recorded today
+WhatNewMovies do i have any new {MovieGenre} movies recorded tonight
+WhatNewMovies do i have any new {MovieGenre} movies to watch
+WhatNewMovies do i have any new {MovieGenre} movies to watch today
+WhatNewMovies do i have any new {MovieGenre} movies to watch tonight
+WhatNewMovies do i have any new {MovieGenre} movies today
+WhatNewMovies do i have any new {MovieGenre} movies tonight
 WhatNewMovies do i have new films
 WhatNewMovies do i have new films to watch
 WhatNewMovies do i have new movies
 WhatNewMovies do i have new movies to watch
-WhatNewMovies do i have new {Genre} films
-WhatNewMovies do i have new {Genre} films recorded
-WhatNewMovies do i have new {Genre} films recorded to watch
-WhatNewMovies do i have new {Genre} films recorded to watch today
-WhatNewMovies do i have new {Genre} films recorded to watch tonight
-WhatNewMovies do i have new {Genre} films recorded today
-WhatNewMovies do i have new {Genre} films recorded tonight
-WhatNewMovies do i have new {Genre} films to watch
-WhatNewMovies do i have new {Genre} films to watch today
-WhatNewMovies do i have new {Genre} films to watch tonight
-WhatNewMovies do i have new {Genre} films today
-WhatNewMovies do i have new {Genre} films tonight
-WhatNewMovies do i have new {Genre} movies
-WhatNewMovies do i have new {Genre} movies recorded
-WhatNewMovies do i have new {Genre} movies recorded to watch
-WhatNewMovies do i have new {Genre} movies recorded to watch today
-WhatNewMovies do i have new {Genre} movies recorded to watch tonight
-WhatNewMovies do i have new {Genre} movies recorded today
-WhatNewMovies do i have new {Genre} movies recorded tonight
-WhatNewMovies do i have new {Genre} movies to watch
-WhatNewMovies do i have new {Genre} movies to watch today
-WhatNewMovies do i have new {Genre} movies to watch tonight
-WhatNewMovies do i have new {Genre} movies today
-WhatNewMovies do i have new {Genre} movies tonight
-WhatNewMovies do i have some new {Genre} films
-WhatNewMovies do i have some new {Genre} films recorded
-WhatNewMovies do i have some new {Genre} films recorded to watch
-WhatNewMovies do i have some new {Genre} films recorded to watch today
-WhatNewMovies do i have some new {Genre} films recorded to watch tonight
-WhatNewMovies do i have some new {Genre} films recorded today
-WhatNewMovies do i have some new {Genre} films recorded tonight
-WhatNewMovies do i have some new {Genre} films to watch
-WhatNewMovies do i have some new {Genre} films to watch today
-WhatNewMovies do i have some new {Genre} films to watch tonight
-WhatNewMovies do i have some new {Genre} films today
-WhatNewMovies do i have some new {Genre} films tonight
-WhatNewMovies do i have some new {Genre} movies
-WhatNewMovies do i have some new {Genre} movies recorded
-WhatNewMovies do i have some new {Genre} movies recorded to watch
-WhatNewMovies do i have some new {Genre} movies recorded to watch today
-WhatNewMovies do i have some new {Genre} movies recorded to watch tonight
-WhatNewMovies do i have some new {Genre} movies recorded today
-WhatNewMovies do i have some new {Genre} movies recorded tonight
-WhatNewMovies do i have some new {Genre} movies to watch
-WhatNewMovies do i have some new {Genre} movies to watch today
-WhatNewMovies do i have some new {Genre} movies to watch tonight
-WhatNewMovies do i have some new {Genre} movies today
-WhatNewMovies do i have some new {Genre} movies tonight
-WhatNewMovies do we have a new {Genre} film
-WhatNewMovies do we have a new {Genre} film recorded
-WhatNewMovies do we have a new {Genre} film recorded to watch
-WhatNewMovies do we have a new {Genre} film recorded to watch today
-WhatNewMovies do we have a new {Genre} film recorded to watch tonight
-WhatNewMovies do we have a new {Genre} film recorded today
-WhatNewMovies do we have a new {Genre} film recorded tonight
-WhatNewMovies do we have a new {Genre} film to watch
-WhatNewMovies do we have a new {Genre} film to watch today
-WhatNewMovies do we have a new {Genre} film to watch tonight
-WhatNewMovies do we have a new {Genre} film today
-WhatNewMovies do we have a new {Genre} film tonight
-WhatNewMovies do we have a new {Genre} movie
-WhatNewMovies do we have a new {Genre} movie recorded
-WhatNewMovies do we have a new {Genre} movie recorded to watch
-WhatNewMovies do we have a new {Genre} movie recorded to watch today
-WhatNewMovies do we have a new {Genre} movie recorded to watch tonight
-WhatNewMovies do we have a new {Genre} movie recorded today
-WhatNewMovies do we have a new {Genre} movie recorded tonight
-WhatNewMovies do we have a new {Genre} movie to watch
-WhatNewMovies do we have a new {Genre} movie to watch today
-WhatNewMovies do we have a new {Genre} movie to watch tonight
-WhatNewMovies do we have a new {Genre} movie today
-WhatNewMovies do we have a new {Genre} movie tonight
-WhatNewMovies do we have any new {Genre} films
-WhatNewMovies do we have any new {Genre} films recorded
-WhatNewMovies do we have any new {Genre} films recorded to watch
-WhatNewMovies do we have any new {Genre} films recorded to watch today
-WhatNewMovies do we have any new {Genre} films recorded to watch tonight
-WhatNewMovies do we have any new {Genre} films recorded today
-WhatNewMovies do we have any new {Genre} films recorded tonight
-WhatNewMovies do we have any new {Genre} films to watch
-WhatNewMovies do we have any new {Genre} films to watch today
-WhatNewMovies do we have any new {Genre} films to watch tonight
-WhatNewMovies do we have any new {Genre} films today
-WhatNewMovies do we have any new {Genre} films tonight
-WhatNewMovies do we have any new {Genre} movies
-WhatNewMovies do we have any new {Genre} movies recorded
-WhatNewMovies do we have any new {Genre} movies recorded to watch
-WhatNewMovies do we have any new {Genre} movies recorded to watch today
-WhatNewMovies do we have any new {Genre} movies recorded to watch tonight
-WhatNewMovies do we have any new {Genre} movies recorded today
-WhatNewMovies do we have any new {Genre} movies recorded tonight
-WhatNewMovies do we have any new {Genre} movies to watch
-WhatNewMovies do we have any new {Genre} movies to watch today
-WhatNewMovies do we have any new {Genre} movies to watch tonight
-WhatNewMovies do we have any new {Genre} movies today
-WhatNewMovies do we have any new {Genre} movies tonight
-WhatNewMovies do we have new {Genre} films
-WhatNewMovies do we have new {Genre} films recorded
-WhatNewMovies do we have new {Genre} films recorded to watch
-WhatNewMovies do we have new {Genre} films recorded to watch today
-WhatNewMovies do we have new {Genre} films recorded to watch tonight
-WhatNewMovies do we have new {Genre} films recorded today
-WhatNewMovies do we have new {Genre} films recorded tonight
-WhatNewMovies do we have new {Genre} films to watch
-WhatNewMovies do we have new {Genre} films to watch today
-WhatNewMovies do we have new {Genre} films to watch tonight
-WhatNewMovies do we have new {Genre} films today
-WhatNewMovies do we have new {Genre} films tonight
-WhatNewMovies do we have new {Genre} movies
-WhatNewMovies do we have new {Genre} movies recorded
-WhatNewMovies do we have new {Genre} movies recorded to watch
-WhatNewMovies do we have new {Genre} movies recorded to watch today
-WhatNewMovies do we have new {Genre} movies recorded to watch tonight
-WhatNewMovies do we have new {Genre} movies recorded today
-WhatNewMovies do we have new {Genre} movies recorded tonight
-WhatNewMovies do we have new {Genre} movies to watch
-WhatNewMovies do we have new {Genre} movies to watch today
-WhatNewMovies do we have new {Genre} movies to watch tonight
-WhatNewMovies do we have new {Genre} movies today
-WhatNewMovies do we have new {Genre} movies tonight
-WhatNewMovies do we have some new {Genre} films
-WhatNewMovies do we have some new {Genre} films recorded
-WhatNewMovies do we have some new {Genre} films recorded to watch
-WhatNewMovies do we have some new {Genre} films recorded to watch today
-WhatNewMovies do we have some new {Genre} films recorded to watch tonight
-WhatNewMovies do we have some new {Genre} films recorded today
-WhatNewMovies do we have some new {Genre} films recorded tonight
-WhatNewMovies do we have some new {Genre} films to watch
-WhatNewMovies do we have some new {Genre} films to watch today
-WhatNewMovies do we have some new {Genre} films to watch tonight
-WhatNewMovies do we have some new {Genre} films today
-WhatNewMovies do we have some new {Genre} films tonight
-WhatNewMovies do we have some new {Genre} movies
-WhatNewMovies do we have some new {Genre} movies recorded
-WhatNewMovies do we have some new {Genre} movies recorded to watch
-WhatNewMovies do we have some new {Genre} movies recorded to watch today
-WhatNewMovies do we have some new {Genre} movies recorded to watch tonight
-WhatNewMovies do we have some new {Genre} movies recorded today
-WhatNewMovies do we have some new {Genre} movies recorded tonight
-WhatNewMovies do we have some new {Genre} movies to watch
-WhatNewMovies do we have some new {Genre} movies to watch today
-WhatNewMovies do we have some new {Genre} movies to watch tonight
-WhatNewMovies do we have some new {Genre} movies today
-WhatNewMovies do we have some new {Genre} movies tonight
-WhatNewMovies if there are any new {Genre} films
-WhatNewMovies if there are any new {Genre} films recorded
-WhatNewMovies if there are any new {Genre} films recorded to watch
-WhatNewMovies if there are any new {Genre} films recorded to watch today
-WhatNewMovies if there are any new {Genre} films recorded to watch tonight
-WhatNewMovies if there are any new {Genre} films recorded today
-WhatNewMovies if there are any new {Genre} films recorded tonight
-WhatNewMovies if there are any new {Genre} films to watch
-WhatNewMovies if there are any new {Genre} films to watch today
-WhatNewMovies if there are any new {Genre} films to watch tonight
-WhatNewMovies if there are any new {Genre} films today
-WhatNewMovies if there are any new {Genre} films tonight
-WhatNewMovies if there are any new {Genre} movies
-WhatNewMovies if there are any new {Genre} movies recorded
-WhatNewMovies if there are any new {Genre} movies recorded to watch
-WhatNewMovies if there are any new {Genre} movies recorded to watch today
-WhatNewMovies if there are any new {Genre} movies recorded to watch tonight
-WhatNewMovies if there are any new {Genre} movies recorded today
-WhatNewMovies if there are any new {Genre} movies recorded tonight
-WhatNewMovies if there are any new {Genre} movies to watch
-WhatNewMovies if there are any new {Genre} movies to watch today
-WhatNewMovies if there are any new {Genre} movies to watch tonight
-WhatNewMovies if there are any new {Genre} movies today
-WhatNewMovies if there are any new {Genre} movies tonight
+WhatNewMovies do i have new {MovieGenre} films
+WhatNewMovies do i have new {MovieGenre} films recorded
+WhatNewMovies do i have new {MovieGenre} films recorded to watch
+WhatNewMovies do i have new {MovieGenre} films recorded to watch today
+WhatNewMovies do i have new {MovieGenre} films recorded to watch tonight
+WhatNewMovies do i have new {MovieGenre} films recorded today
+WhatNewMovies do i have new {MovieGenre} films recorded tonight
+WhatNewMovies do i have new {MovieGenre} films to watch
+WhatNewMovies do i have new {MovieGenre} films to watch today
+WhatNewMovies do i have new {MovieGenre} films to watch tonight
+WhatNewMovies do i have new {MovieGenre} films today
+WhatNewMovies do i have new {MovieGenre} films tonight
+WhatNewMovies do i have new {MovieGenre} movies
+WhatNewMovies do i have new {MovieGenre} movies recorded
+WhatNewMovies do i have new {MovieGenre} movies recorded to watch
+WhatNewMovies do i have new {MovieGenre} movies recorded to watch today
+WhatNewMovies do i have new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies do i have new {MovieGenre} movies recorded today
+WhatNewMovies do i have new {MovieGenre} movies recorded tonight
+WhatNewMovies do i have new {MovieGenre} movies to watch
+WhatNewMovies do i have new {MovieGenre} movies to watch today
+WhatNewMovies do i have new {MovieGenre} movies to watch tonight
+WhatNewMovies do i have new {MovieGenre} movies today
+WhatNewMovies do i have new {MovieGenre} movies tonight
+WhatNewMovies do i have some new {MovieGenre} films
+WhatNewMovies do i have some new {MovieGenre} films recorded
+WhatNewMovies do i have some new {MovieGenre} films recorded to watch
+WhatNewMovies do i have some new {MovieGenre} films recorded to watch today
+WhatNewMovies do i have some new {MovieGenre} films recorded to watch tonight
+WhatNewMovies do i have some new {MovieGenre} films recorded today
+WhatNewMovies do i have some new {MovieGenre} films recorded tonight
+WhatNewMovies do i have some new {MovieGenre} films to watch
+WhatNewMovies do i have some new {MovieGenre} films to watch today
+WhatNewMovies do i have some new {MovieGenre} films to watch tonight
+WhatNewMovies do i have some new {MovieGenre} films today
+WhatNewMovies do i have some new {MovieGenre} films tonight
+WhatNewMovies do i have some new {MovieGenre} movies
+WhatNewMovies do i have some new {MovieGenre} movies recorded
+WhatNewMovies do i have some new {MovieGenre} movies recorded to watch
+WhatNewMovies do i have some new {MovieGenre} movies recorded to watch today
+WhatNewMovies do i have some new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies do i have some new {MovieGenre} movies recorded today
+WhatNewMovies do i have some new {MovieGenre} movies recorded tonight
+WhatNewMovies do i have some new {MovieGenre} movies to watch
+WhatNewMovies do i have some new {MovieGenre} movies to watch today
+WhatNewMovies do i have some new {MovieGenre} movies to watch tonight
+WhatNewMovies do i have some new {MovieGenre} movies today
+WhatNewMovies do i have some new {MovieGenre} movies tonight
+WhatNewMovies do we have a new {MovieGenre} film
+WhatNewMovies do we have a new {MovieGenre} film recorded
+WhatNewMovies do we have a new {MovieGenre} film recorded to watch
+WhatNewMovies do we have a new {MovieGenre} film recorded to watch today
+WhatNewMovies do we have a new {MovieGenre} film recorded to watch tonight
+WhatNewMovies do we have a new {MovieGenre} film recorded today
+WhatNewMovies do we have a new {MovieGenre} film recorded tonight
+WhatNewMovies do we have a new {MovieGenre} film to watch
+WhatNewMovies do we have a new {MovieGenre} film to watch today
+WhatNewMovies do we have a new {MovieGenre} film to watch tonight
+WhatNewMovies do we have a new {MovieGenre} film today
+WhatNewMovies do we have a new {MovieGenre} film tonight
+WhatNewMovies do we have a new {MovieGenre} movie
+WhatNewMovies do we have a new {MovieGenre} movie recorded
+WhatNewMovies do we have a new {MovieGenre} movie recorded to watch
+WhatNewMovies do we have a new {MovieGenre} movie recorded to watch today
+WhatNewMovies do we have a new {MovieGenre} movie recorded to watch tonight
+WhatNewMovies do we have a new {MovieGenre} movie recorded today
+WhatNewMovies do we have a new {MovieGenre} movie recorded tonight
+WhatNewMovies do we have a new {MovieGenre} movie to watch
+WhatNewMovies do we have a new {MovieGenre} movie to watch today
+WhatNewMovies do we have a new {MovieGenre} movie to watch tonight
+WhatNewMovies do we have a new {MovieGenre} movie today
+WhatNewMovies do we have a new {MovieGenre} movie tonight
+WhatNewMovies do we have any new {MovieGenre} films
+WhatNewMovies do we have any new {MovieGenre} films recorded
+WhatNewMovies do we have any new {MovieGenre} films recorded to watch
+WhatNewMovies do we have any new {MovieGenre} films recorded to watch today
+WhatNewMovies do we have any new {MovieGenre} films recorded to watch tonight
+WhatNewMovies do we have any new {MovieGenre} films recorded today
+WhatNewMovies do we have any new {MovieGenre} films recorded tonight
+WhatNewMovies do we have any new {MovieGenre} films to watch
+WhatNewMovies do we have any new {MovieGenre} films to watch today
+WhatNewMovies do we have any new {MovieGenre} films to watch tonight
+WhatNewMovies do we have any new {MovieGenre} films today
+WhatNewMovies do we have any new {MovieGenre} films tonight
+WhatNewMovies do we have any new {MovieGenre} movies
+WhatNewMovies do we have any new {MovieGenre} movies recorded
+WhatNewMovies do we have any new {MovieGenre} movies recorded to watch
+WhatNewMovies do we have any new {MovieGenre} movies recorded to watch today
+WhatNewMovies do we have any new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies do we have any new {MovieGenre} movies recorded today
+WhatNewMovies do we have any new {MovieGenre} movies recorded tonight
+WhatNewMovies do we have any new {MovieGenre} movies to watch
+WhatNewMovies do we have any new {MovieGenre} movies to watch today
+WhatNewMovies do we have any new {MovieGenre} movies to watch tonight
+WhatNewMovies do we have any new {MovieGenre} movies today
+WhatNewMovies do we have any new {MovieGenre} movies tonight
+WhatNewMovies do we have new {MovieGenre} films
+WhatNewMovies do we have new {MovieGenre} films recorded
+WhatNewMovies do we have new {MovieGenre} films recorded to watch
+WhatNewMovies do we have new {MovieGenre} films recorded to watch today
+WhatNewMovies do we have new {MovieGenre} films recorded to watch tonight
+WhatNewMovies do we have new {MovieGenre} films recorded today
+WhatNewMovies do we have new {MovieGenre} films recorded tonight
+WhatNewMovies do we have new {MovieGenre} films to watch
+WhatNewMovies do we have new {MovieGenre} films to watch today
+WhatNewMovies do we have new {MovieGenre} films to watch tonight
+WhatNewMovies do we have new {MovieGenre} films today
+WhatNewMovies do we have new {MovieGenre} films tonight
+WhatNewMovies do we have new {MovieGenre} movies
+WhatNewMovies do we have new {MovieGenre} movies recorded
+WhatNewMovies do we have new {MovieGenre} movies recorded to watch
+WhatNewMovies do we have new {MovieGenre} movies recorded to watch today
+WhatNewMovies do we have new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies do we have new {MovieGenre} movies recorded today
+WhatNewMovies do we have new {MovieGenre} movies recorded tonight
+WhatNewMovies do we have new {MovieGenre} movies to watch
+WhatNewMovies do we have new {MovieGenre} movies to watch today
+WhatNewMovies do we have new {MovieGenre} movies to watch tonight
+WhatNewMovies do we have new {MovieGenre} movies today
+WhatNewMovies do we have new {MovieGenre} movies tonight
+WhatNewMovies do we have some new {MovieGenre} films
+WhatNewMovies do we have some new {MovieGenre} films recorded
+WhatNewMovies do we have some new {MovieGenre} films recorded to watch
+WhatNewMovies do we have some new {MovieGenre} films recorded to watch today
+WhatNewMovies do we have some new {MovieGenre} films recorded to watch tonight
+WhatNewMovies do we have some new {MovieGenre} films recorded today
+WhatNewMovies do we have some new {MovieGenre} films recorded tonight
+WhatNewMovies do we have some new {MovieGenre} films to watch
+WhatNewMovies do we have some new {MovieGenre} films to watch today
+WhatNewMovies do we have some new {MovieGenre} films to watch tonight
+WhatNewMovies do we have some new {MovieGenre} films today
+WhatNewMovies do we have some new {MovieGenre} films tonight
+WhatNewMovies do we have some new {MovieGenre} movies
+WhatNewMovies do we have some new {MovieGenre} movies recorded
+WhatNewMovies do we have some new {MovieGenre} movies recorded to watch
+WhatNewMovies do we have some new {MovieGenre} movies recorded to watch today
+WhatNewMovies do we have some new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies do we have some new {MovieGenre} movies recorded today
+WhatNewMovies do we have some new {MovieGenre} movies recorded tonight
+WhatNewMovies do we have some new {MovieGenre} movies to watch
+WhatNewMovies do we have some new {MovieGenre} movies to watch today
+WhatNewMovies do we have some new {MovieGenre} movies to watch tonight
+WhatNewMovies do we have some new {MovieGenre} movies today
+WhatNewMovies do we have some new {MovieGenre} movies tonight
+WhatNewMovies if there are any new {MovieGenre} films
+WhatNewMovies if there are any new {MovieGenre} films recorded
+WhatNewMovies if there are any new {MovieGenre} films recorded to watch
+WhatNewMovies if there are any new {MovieGenre} films recorded to watch today
+WhatNewMovies if there are any new {MovieGenre} films recorded to watch tonight
+WhatNewMovies if there are any new {MovieGenre} films recorded today
+WhatNewMovies if there are any new {MovieGenre} films recorded tonight
+WhatNewMovies if there are any new {MovieGenre} films to watch
+WhatNewMovies if there are any new {MovieGenre} films to watch today
+WhatNewMovies if there are any new {MovieGenre} films to watch tonight
+WhatNewMovies if there are any new {MovieGenre} films today
+WhatNewMovies if there are any new {MovieGenre} films tonight
+WhatNewMovies if there are any new {MovieGenre} movies
+WhatNewMovies if there are any new {MovieGenre} movies recorded
+WhatNewMovies if there are any new {MovieGenre} movies recorded to watch
+WhatNewMovies if there are any new {MovieGenre} movies recorded to watch today
+WhatNewMovies if there are any new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies if there are any new {MovieGenre} movies recorded today
+WhatNewMovies if there are any new {MovieGenre} movies recorded tonight
+WhatNewMovies if there are any new {MovieGenre} movies to watch
+WhatNewMovies if there are any new {MovieGenre} movies to watch today
+WhatNewMovies if there are any new {MovieGenre} movies to watch tonight
+WhatNewMovies if there are any new {MovieGenre} movies today
+WhatNewMovies if there are any new {MovieGenre} movies tonight
 WhatNewMovies if there are new films
 WhatNewMovies if there are new films to watch
 WhatNewMovies if there are new movies
 WhatNewMovies if there are new movies to watch
-WhatNewMovies if there are new {Genre} films
-WhatNewMovies if there are new {Genre} films recorded
-WhatNewMovies if there are new {Genre} films recorded to watch
-WhatNewMovies if there are new {Genre} films recorded to watch today
-WhatNewMovies if there are new {Genre} films recorded to watch tonight
-WhatNewMovies if there are new {Genre} films recorded today
-WhatNewMovies if there are new {Genre} films recorded tonight
-WhatNewMovies if there are new {Genre} films to watch
-WhatNewMovies if there are new {Genre} films to watch today
-WhatNewMovies if there are new {Genre} films to watch tonight
-WhatNewMovies if there are new {Genre} films today
-WhatNewMovies if there are new {Genre} films tonight
-WhatNewMovies if there are new {Genre} movies
-WhatNewMovies if there are new {Genre} movies recorded
-WhatNewMovies if there are new {Genre} movies recorded to watch
-WhatNewMovies if there are new {Genre} movies recorded to watch today
-WhatNewMovies if there are new {Genre} movies recorded to watch tonight
-WhatNewMovies if there are new {Genre} movies recorded today
-WhatNewMovies if there are new {Genre} movies recorded tonight
-WhatNewMovies if there are new {Genre} movies to watch
-WhatNewMovies if there are new {Genre} movies to watch today
-WhatNewMovies if there are new {Genre} movies to watch tonight
-WhatNewMovies if there are new {Genre} movies today
-WhatNewMovies if there are new {Genre} movies tonight
-WhatNewMovies if there are some new {Genre} films
-WhatNewMovies if there are some new {Genre} films recorded
-WhatNewMovies if there are some new {Genre} films recorded to watch
-WhatNewMovies if there are some new {Genre} films recorded to watch today
-WhatNewMovies if there are some new {Genre} films recorded to watch tonight
-WhatNewMovies if there are some new {Genre} films recorded today
-WhatNewMovies if there are some new {Genre} films recorded tonight
-WhatNewMovies if there are some new {Genre} films to watch
-WhatNewMovies if there are some new {Genre} films to watch today
-WhatNewMovies if there are some new {Genre} films to watch tonight
-WhatNewMovies if there are some new {Genre} films today
-WhatNewMovies if there are some new {Genre} films tonight
-WhatNewMovies if there are some new {Genre} movies
-WhatNewMovies if there are some new {Genre} movies recorded
-WhatNewMovies if there are some new {Genre} movies recorded to watch
-WhatNewMovies if there are some new {Genre} movies recorded to watch today
-WhatNewMovies if there are some new {Genre} movies recorded to watch tonight
-WhatNewMovies if there are some new {Genre} movies recorded today
-WhatNewMovies if there are some new {Genre} movies recorded tonight
-WhatNewMovies if there are some new {Genre} movies to watch
-WhatNewMovies if there are some new {Genre} movies to watch today
-WhatNewMovies if there are some new {Genre} movies to watch tonight
-WhatNewMovies if there are some new {Genre} movies today
-WhatNewMovies if there are some new {Genre} movies tonight
+WhatNewMovies if there are new {MovieGenre} films
+WhatNewMovies if there are new {MovieGenre} films recorded
+WhatNewMovies if there are new {MovieGenre} films recorded to watch
+WhatNewMovies if there are new {MovieGenre} films recorded to watch today
+WhatNewMovies if there are new {MovieGenre} films recorded to watch tonight
+WhatNewMovies if there are new {MovieGenre} films recorded today
+WhatNewMovies if there are new {MovieGenre} films recorded tonight
+WhatNewMovies if there are new {MovieGenre} films to watch
+WhatNewMovies if there are new {MovieGenre} films to watch today
+WhatNewMovies if there are new {MovieGenre} films to watch tonight
+WhatNewMovies if there are new {MovieGenre} films today
+WhatNewMovies if there are new {MovieGenre} films tonight
+WhatNewMovies if there are new {MovieGenre} movies
+WhatNewMovies if there are new {MovieGenre} movies recorded
+WhatNewMovies if there are new {MovieGenre} movies recorded to watch
+WhatNewMovies if there are new {MovieGenre} movies recorded to watch today
+WhatNewMovies if there are new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies if there are new {MovieGenre} movies recorded today
+WhatNewMovies if there are new {MovieGenre} movies recorded tonight
+WhatNewMovies if there are new {MovieGenre} movies to watch
+WhatNewMovies if there are new {MovieGenre} movies to watch today
+WhatNewMovies if there are new {MovieGenre} movies to watch tonight
+WhatNewMovies if there are new {MovieGenre} movies today
+WhatNewMovies if there are new {MovieGenre} movies tonight
+WhatNewMovies if there are some new {MovieGenre} films
+WhatNewMovies if there are some new {MovieGenre} films recorded
+WhatNewMovies if there are some new {MovieGenre} films recorded to watch
+WhatNewMovies if there are some new {MovieGenre} films recorded to watch today
+WhatNewMovies if there are some new {MovieGenre} films recorded to watch tonight
+WhatNewMovies if there are some new {MovieGenre} films recorded today
+WhatNewMovies if there are some new {MovieGenre} films recorded tonight
+WhatNewMovies if there are some new {MovieGenre} films to watch
+WhatNewMovies if there are some new {MovieGenre} films to watch today
+WhatNewMovies if there are some new {MovieGenre} films to watch tonight
+WhatNewMovies if there are some new {MovieGenre} films today
+WhatNewMovies if there are some new {MovieGenre} films tonight
+WhatNewMovies if there are some new {MovieGenre} movies
+WhatNewMovies if there are some new {MovieGenre} movies recorded
+WhatNewMovies if there are some new {MovieGenre} movies recorded to watch
+WhatNewMovies if there are some new {MovieGenre} movies recorded to watch today
+WhatNewMovies if there are some new {MovieGenre} movies recorded to watch tonight
+WhatNewMovies if there are some new {MovieGenre} movies recorded today
+WhatNewMovies if there are some new {MovieGenre} movies recorded tonight
+WhatNewMovies if there are some new {MovieGenre} movies to watch
+WhatNewMovies if there are some new {MovieGenre} movies to watch today
+WhatNewMovies if there are some new {MovieGenre} movies to watch tonight
+WhatNewMovies if there are some new {MovieGenre} movies today
+WhatNewMovies if there are some new {MovieGenre} movies tonight
 WhatNewMovies if there is a new film
 WhatNewMovies if there is a new film to watch
 WhatNewMovies if there is a new movie
 WhatNewMovies if there is a new movie to watch
-WhatNewMovies if there is a new {Genre} film
-WhatNewMovies if there is a new {Genre} film recorded
-WhatNewMovies if there is a new {Genre} film recorded to watch
-WhatNewMovies if there is a new {Genre} film recorded to watch today
-WhatNewMovies if there is a new {Genre} film recorded to watch tonight
-WhatNewMovies if there is a new {Genre} film recorded today
-WhatNewMovies if there is a new {Genre} film recorded tonight
-WhatNewMovies if there is a new {Genre} film to watch
-WhatNewMovies if there is a new {Genre} film to watch today
-WhatNewMovies if there is a new {Genre} film to watch tonight
-WhatNewMovies if there is a new {Genre} film today
-WhatNewMovies if there is a new {Genre} film tonight
-WhatNewMovies if there is a new {Genre} movie
-WhatNewMovies if there is a new {Genre} movie recorded
-WhatNewMovies if there is a new {Genre} movie recorded to watch
-WhatNewMovies if there is a new {Genre} movie recorded to watch today
-WhatNewMovies if there is a new {Genre} movie recorded to watch tonight
-WhatNewMovies if there is a new {Genre} movie recorded today
-WhatNewMovies if there is a new {Genre} movie recorded tonight
-WhatNewMovies if there is a new {Genre} movie to watch
-WhatNewMovies if there is a new {Genre} movie to watch today
-WhatNewMovies if there is a new {Genre} movie to watch tonight
-WhatNewMovies if there is a new {Genre} movie today
-WhatNewMovies if there is a new {Genre} movie tonight
+WhatNewMovies if there is a new {MovieGenre} film
+WhatNewMovies if there is a new {MovieGenre} film recorded
+WhatNewMovies if there is a new {MovieGenre} film recorded to watch
+WhatNewMovies if there is a new {MovieGenre} film recorded to watch today
+WhatNewMovies if there is a new {MovieGenre} film recorded to watch tonight
+WhatNewMovies if there is a new {MovieGenre} film recorded today
+WhatNewMovies if there is a new {MovieGenre} film recorded tonight
+WhatNewMovies if there is a new {MovieGenre} film to watch
+WhatNewMovies if there is a new {MovieGenre} film to watch today
+WhatNewMovies if there is a new {MovieGenre} film to watch tonight
+WhatNewMovies if there is a new {MovieGenre} film today
+WhatNewMovies if there is a new {MovieGenre} film tonight
+WhatNewMovies if there is a new {MovieGenre} movie
+WhatNewMovies if there is a new {MovieGenre} movie recorded
+WhatNewMovies if there is a new {MovieGenre} movie recorded to watch
+WhatNewMovies if there is a new {MovieGenre} movie recorded to watch today
+WhatNewMovies if there is a new {MovieGenre} movie recorded to watch tonight
+WhatNewMovies if there is a new {MovieGenre} movie recorded today
+WhatNewMovies if there is a new {MovieGenre} movie recorded tonight
+WhatNewMovies if there is a new {MovieGenre} movie to watch
+WhatNewMovies if there is a new {MovieGenre} movie to watch today
+WhatNewMovies if there is a new {MovieGenre} movie to watch tonight
+WhatNewMovies if there is a new {MovieGenre} movie today
+WhatNewMovies if there is a new {MovieGenre} movie tonight
 WhatNewMovies is there a new film
 WhatNewMovies is there a new film to watch
 WhatNewMovies is there a new movie
 WhatNewMovies is there a new movie to watch
-WhatNewMovies is there a new {Genre} film
-WhatNewMovies is there a new {Genre} film recorded
-WhatNewMovies is there a new {Genre} film recorded to watch
-WhatNewMovies is there a new {Genre} film recorded to watch today
-WhatNewMovies is there a new {Genre} film recorded to watch tonight
-WhatNewMovies is there a new {Genre} film recorded today
-WhatNewMovies is there a new {Genre} film recorded tonight
-WhatNewMovies is there a new {Genre} film to watch
-WhatNewMovies is there a new {Genre} film to watch today
-WhatNewMovies is there a new {Genre} film to watch tonight
-WhatNewMovies is there a new {Genre} film today
-WhatNewMovies is there a new {Genre} film tonight
-WhatNewMovies is there a new {Genre} movie
-WhatNewMovies is there a new {Genre} movie recorded
-WhatNewMovies is there a new {Genre} movie recorded to watch
-WhatNewMovies is there a new {Genre} movie recorded to watch today
-WhatNewMovies is there a new {Genre} movie recorded to watch tonight
-WhatNewMovies is there a new {Genre} movie recorded today
-WhatNewMovies is there a new {Genre} movie recorded tonight
-WhatNewMovies is there a new {Genre} movie to watch
-WhatNewMovies is there a new {Genre} movie to watch today
-WhatNewMovies is there a new {Genre} movie to watch tonight
-WhatNewMovies is there a new {Genre} movie today
-WhatNewMovies is there a new {Genre} movie tonight
+WhatNewMovies is there a new {MovieGenre} film
+WhatNewMovies is there a new {MovieGenre} film recorded
+WhatNewMovies is there a new {MovieGenre} film recorded to watch
+WhatNewMovies is there a new {MovieGenre} film recorded to watch today
+WhatNewMovies is there a new {MovieGenre} film recorded to watch tonight
+WhatNewMovies is there a new {MovieGenre} film recorded today
+WhatNewMovies is there a new {MovieGenre} film recorded tonight
+WhatNewMovies is there a new {MovieGenre} film to watch
+WhatNewMovies is there a new {MovieGenre} film to watch today
+WhatNewMovies is there a new {MovieGenre} film to watch tonight
+WhatNewMovies is there a new {MovieGenre} film today
+WhatNewMovies is there a new {MovieGenre} film tonight
+WhatNewMovies is there a new {MovieGenre} movie
+WhatNewMovies is there a new {MovieGenre} movie recorded
+WhatNewMovies is there a new {MovieGenre} movie recorded to watch
+WhatNewMovies is there a new {MovieGenre} movie recorded to watch today
+WhatNewMovies is there a new {MovieGenre} movie recorded to watch tonight
+WhatNewMovies is there a new {MovieGenre} movie recorded today
+WhatNewMovies is there a new {MovieGenre} movie recorded tonight
+WhatNewMovies is there a new {MovieGenre} movie to watch
+WhatNewMovies is there a new {MovieGenre} movie to watch today
+WhatNewMovies is there a new {MovieGenre} movie to watch tonight
+WhatNewMovies is there a new {MovieGenre} movie today
+WhatNewMovies is there a new {MovieGenre} movie tonight
 WhatNewMovies what new films are there
 WhatNewMovies what new films are there to watch
 WhatNewMovies what new films do i have
@@ -1157,34 +1172,34 @@ WhatNewMovies what new movies are there
 WhatNewMovies what new movies are there to watch
 WhatNewMovies what new movies do i have
 WhatNewMovies what new movies do i have to watch
-WhatNewMovies what new {Genre} films are there
-WhatNewMovies what new {Genre} films do i have
-WhatNewMovies what new {Genre} films do we have
-WhatNewMovies what new {Genre} films do you have
-WhatNewMovies what new {Genre} films i have
-WhatNewMovies what new {Genre} films we have
-WhatNewMovies what new {Genre} films you have
-WhatNewMovies what new {Genre} movies are there
-WhatNewMovies what new {Genre} movies do i have
-WhatNewMovies what new {Genre} movies do we have
-WhatNewMovies what new {Genre} movies do you have
-WhatNewMovies what new {Genre} movies i have
-WhatNewMovies what new {Genre} movies we have
-WhatNewMovies what new {Genre} movies you have
-WhatNewMovies what {Genre} films are there
-WhatNewMovies what {Genre} films do i have
-WhatNewMovies what {Genre} films do we have
-WhatNewMovies what {Genre} films do you have
-WhatNewMovies what {Genre} films i have
-WhatNewMovies what {Genre} films we have
-WhatNewMovies what {Genre} films you have
-WhatNewMovies what {Genre} movies are there
-WhatNewMovies what {Genre} movies do i have
-WhatNewMovies what {Genre} movies do we have
-WhatNewMovies what {Genre} movies do you have
-WhatNewMovies what {Genre} movies i have
-WhatNewMovies what {Genre} movies we have
-WhatNewMovies what {Genre} movies you have
+WhatNewMovies what new {MovieGenre} films are there
+WhatNewMovies what new {MovieGenre} films do i have
+WhatNewMovies what new {MovieGenre} films do we have
+WhatNewMovies what new {MovieGenre} films do you have
+WhatNewMovies what new {MovieGenre} films i have
+WhatNewMovies what new {MovieGenre} films we have
+WhatNewMovies what new {MovieGenre} films you have
+WhatNewMovies what new {MovieGenre} movies are there
+WhatNewMovies what new {MovieGenre} movies do i have
+WhatNewMovies what new {MovieGenre} movies do we have
+WhatNewMovies what new {MovieGenre} movies do you have
+WhatNewMovies what new {MovieGenre} movies i have
+WhatNewMovies what new {MovieGenre} movies we have
+WhatNewMovies what new {MovieGenre} movies you have
+WhatNewMovies what {MovieGenre} films are there
+WhatNewMovies what {MovieGenre} films do i have
+WhatNewMovies what {MovieGenre} films do we have
+WhatNewMovies what {MovieGenre} films do you have
+WhatNewMovies what {MovieGenre} films i have
+WhatNewMovies what {MovieGenre} films we have
+WhatNewMovies what {MovieGenre} films you have
+WhatNewMovies what {MovieGenre} movies are there
+WhatNewMovies what {MovieGenre} movies do i have
+WhatNewMovies what {MovieGenre} movies do we have
+WhatNewMovies what {MovieGenre} movies do you have
+WhatNewMovies what {MovieGenre} movies i have
+WhatNewMovies what {MovieGenre} movies we have
+WhatNewMovies what {MovieGenre} movies you have
 WhatNewShows are there new shows
 WhatNewShows are there new shows to watch
 WhatNewShows do i have a new show

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -8,7 +8,11 @@ could_not_find: "Konnte {{ heard_name }} nicht finden"
 
 could_not_find_generic: "Konnte diese Formulierung nicht finden"
 
+could_not_find_genre: "Konnte keine {{ genre_name }} Musik finden"
+
 could_not_find_artist: "Konnte keine Musik von {{ artist_name }} finden"
+
+could_not_find_genre_artist: "Konnte keine {{ genre_name }} Musik von {{ artist_name }} finden"
 
 could_not_find_album: "Konnte das Album {{ album_name }} nicht finden"
 
@@ -58,6 +62,10 @@ opening: "Öffne {{ heard_name }}"
 
 playing: "Spiele {{ heard_name }}"
 
+playing_genre: "Spiele {{ genre_name }} Musik"
+
+playing_genre_artist: "Spiele {{ genre_name }} Musik von {{ artist_name }}"
+
 playing_album: "Spiele das Album {{ album_name }}"
 
 playing_album_artist: "Spiele das Album {{ album_name }} von {{ artist }}"
@@ -74,7 +82,7 @@ playing_playlist_video: "{{ action }} Video Playlist {{ playlist_name }}"
 
 playing_party: "Starte Party Play"
 
-playing_genre: "Spiele den {{ genre }} Film {{ movie_name }}"
+playing_genre_movie: "Spiele den {{ genre_name }} Film {{ movie_name }}"
 
 playing_action: "{{ action }} {{ movie_name }}"
 
@@ -178,6 +186,8 @@ big_step_forward: "einen großen Schritt vorwärts"
 big_step_backward: "einen großen Schritt zurück"
 
 listen_artist: "Spiele Musik von {{ heard_artist }}"
+
+listen_artist_genre: "Spiele {{ heard_genre }} Musik von {{ heard_artist }}"
 
 newly_added_shows: "Neu hinzugefügte Serien"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -8,7 +8,11 @@ could_not_find: "Could not find {{ heard_name }}"
 
 could_not_find_generic: "Could not find that phrase"
 
+could_not_find_genre: "Could not find any {{ genre_name }} music"
+
 could_not_find_artist: "Could not find anything by {{ artist_name }}"
+
+could_not_find_genre_artist: "Could not find {{ genre_name }} music by {{ artist_name }}"
 
 could_not_find_album: "Could not find the album {{ album_name }}"
 
@@ -58,6 +62,10 @@ opening: "Opening {{ heard_name }}"
 
 playing: "Playing {{ heard_name }}"
 
+playing_genre: "Playing {{ genre_name }} music"
+
+playing_genre_artist: "Playing {{ genre_name }} music by {{ artist_name }}"
+
 playing_album: "Playing the album {{ album_name }}"
 
 playing_album_artist: "Playing album {{ album_name }} by {{ artist }}"
@@ -74,7 +82,7 @@ playing_playlist_video: "{{ action }} the video playlist {{ playlist_name }}"
 
 playing_party: "Starting party play"
 
-playing_genre: "Playing the {{ genre }} movie {{ movie_name }}"
+playing_genre_movie: "Playing the {{ genre_name }} movie {{ movie_name }}"
 
 playing_action: "{{ action }} {{ movie_name }}"
 
@@ -178,6 +186,8 @@ big_step_forward: "Big step forward"
 big_step_backward: "Big step backward"
 
 listen_artist: "Playing music by {{ heard_artist }}"
+
+listen_artist_genre: "Playing {{ heard_genre }} music by {{ heard_artist }}"
 
 newly_added_shows: "Newly added shows"
 

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -80,7 +80,9 @@ WhatAlbums (welches Album/welche (Alben/CD/CDs/Platte/Platten)) (ich von {Artist
 
 ListenToAudio {Artist} anhören
 
-ListenToArtist spiel(/e) (Musik/Lieder/Songs/Mucke) von (/dem Artist/der Artistin/dem Komponist/der Komponistin/dem Künstler/der Künstlerin/der Band/der Gruppe) {Artist}
+ListenToGenre spiel(/e) {MusicGenre} (Musik/Songs/Genre)
+
+ListenToArtist spiel(/e) (/{MusicGenre}) (Musik/Songs) von (/dem Artist/dem Komponisten/der Komponistin/dem Künstler/der Künstlerin/der Band/der Gruppe/dem Interpreten) {Artist}
 
 ListenToLatestAlbum spiele das (neueste/aktuellste/neue/aktuelle) Album von {Artist}
 ListenToLatestAlbum spiele (aktuelles/neues/neuestes/aktuellstes) Album von {Artist}
@@ -103,7 +105,7 @@ ListenToAudioPlaylistRecent spiel(/e) (zuletzt/kürzlich) hinzugefügte (Musik/L
 
 WatchVideo zeige {Movie}
 
-WatchRandomMovie zeige (/zufälligen) (/{Genre}) Film
+WatchRandomMovie zeige (/zufälligen) (/{MovieGenre}) Film
 
 WatchMovie zeige Film {Movie}
 
@@ -157,12 +159,12 @@ RecommendSong (welches Lied/welchen Song) es (/mir) (empfiehlt/vorschlägt)
 WhatNewAlbums welches neue Album (wartet/(fertig/aufgenommen worden) ist)
 WhatNewAlbums welche neuen Alben (warten/(fertig/aufgenommen worden) sind)
 
-WhatNewMovies welcher (/neue) (/{Genre}) Film (wartet/(fertig/aufgenommen worden) ist)
-WhatNewMovies welche (/neuen) (/{Genre}) Filme (warten/(fertig/aufgenommen worden) sind)
-WhatNewMovies ob es einen neuen (/{Genre}) Film gibt
-WhatNewMovies ob wir einen neuen (/{Genre}) Film haben
-WhatNewMovies ob es neue (/{Genre}) Filme gibt
-WhatNewMovies ob wir neue (/{Genre}) Filme haben
+WhatNewMovies welcher (/neue) (/{MovieGenre}) Film (wartet/(fertig/aufgenommen worden) ist)
+WhatNewMovies welche (/neuen) (/{MovieGenre}) Filme (warten/(fertig/aufgenommen worden) sind)
+WhatNewMovies ob es einen neuen (/{MovieGenre}) Film gibt
+WhatNewMovies ob wir einen neuen (/{MovieGenre}) Film haben
+WhatNewMovies ob es neue (/{MovieGenre}) Filme gibt
+WhatNewMovies ob wir neue (/{MovieGenre}) Filme haben
 
 WhatNewShows welche (/neue) Serie (wartet/(fertig/aufgenommen worden) ist)
 WhatNewShows welche neuen Serien (warten/(fertig/aufgenommen worden) sind)

--- a/utterances.txt
+++ b/utterances.txt
@@ -85,7 +85,9 @@ WhatAlbums what albums (/do) (we/i/you) have by {Artist}
 
 ListenToAudio listen to {Artist}
 
-ListenToArtist (play/listen to/shuffle) (music by/artist) {Artist}
+ListenToGenre (play/listen to/shuffle) {MusicGenre} (music/songs/genre)
+
+ListenToArtist (play/listen to/shuffle) (/{MusicGenre}) (music by/artist) {Artist}
 
 ListenToLatestAlbum (play/listen to) (/the) (latest/newest) album by {Artist}
 
@@ -109,7 +111,7 @@ ListenToAudioPlaylistRecent (play/listen to/shuffle) (latest/newest) (songs/musi
 
 WatchVideo watch {Movie}
 
-WatchRandomMovie (play/watch) (/a) random (/{Genre}) (movie/film)
+WatchRandomMovie (play/watch) (/a) random (/{MovieGenre}) (movie/film)
 
 WatchMovie (play/watch) (/the) (movie/film) {Movie}
 
@@ -167,9 +169,9 @@ WhatNewAlbums what new albums (do i have/are there) (/to listen to)
 WhatNewMovies (if there are/are there/do i have) new (movies/films) (/to watch)
 WhatNewMovies (if there is/is there/do i have) a new (movie/film) (/to watch)
 WhatNewMovies what new (movies/films) (do i have/are there) (/to watch)
-WhatNewMovies (if there are/are there/do (we/i) have) (/any/some) new {Genre} (movies/films) (/recorded) (/to watch) (/today/tonight)
-WhatNewMovies (if there is/is there/do (we/i) have) a new {Genre} (movie/film) (/recorded) (/to watch) (/today/tonight)
-WhatNewMovies what (/new) {Genre} (movies/films) ((/do) (we/i/you) have/are there)
+WhatNewMovies (if there are/are there/do (we/i) have) (/any/some) new {MovieGenre} (movies/films) (/recorded) (/to watch) (/today/tonight)
+WhatNewMovies (if there is/is there/do (we/i) have) a new {MovieGenre} (movie/film) (/recorded) (/to watch) (/today/tonight)
+WhatNewMovies what (/new) {MovieGenre} (movies/films) ((/do) (we/i/you) have/are there)
 
 WhatNewShows (if there are/are there/do i have) new shows (/to watch)
 WhatNewShows (if there is/is there/do i have) a new show (/to watch)


### PR DESCRIPTION
Adds support for requesting music by genre.  With this, you can say things like:

```
play Rock music
listen to Classical genre
shuffle Rap songs
listen to Christmas music by Scott Weiland
```

I've tested it some, but it is definitely possible the utterances might clash, so I wanted to get this up here as a PR for others to play with.

Obviously, the web slot generator needs to be updated to output MUSICGENRES as well.

Addresses Issue #107.