### PR TITLE
Add DownloadSubtitles intent

### DIFF
--- a/alexa.py
+++ b/alexa.py
@@ -2371,6 +2371,14 @@ def alexa_what_albums(Artist):
 
   return question(response_text)
 
+# Handle the DownloadSubtitles intent.
+@ask.intent('DownloadSubtitles')
+def alexa_download_subtitles():
+  print "Downloading subtitles"
+  kodi = Kodi(config, context)
+  item = kodi.DownloadSubtitles()
+  response_text = render_template('short_confirm').encode("utf-8")
+  return question(response_text)
 
 @ask.intent('AMAZON.HelpIntent')
 def prepare_help_message():

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -492,6 +492,9 @@
       "intent": "SubtitlesPrevious"
     },
     {
+      "intent": "DownloadSubtitles"
+    },
+    {
       "intent": "AudioStreamNext"
     },
     {

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -1,3 +1,8 @@
+# A list of utterance variations written in a shorthand syntax
+# Syntax and information
+# Tool to expand the single line into the usable list of utterances
+# http://www.makermusings.com/amazon-echo-utterance-expander/
+# http://www.makermusings.com/two thousand fifteen/seven/twenty one/defining-utterances-for-the-alexa-skills-kit/
 AddonExecute führe add on {Addon} aus
 AddonExecute führe addon {Addon} aus
 AddonExecute führe erweiterung {Addon} aus
@@ -267,6 +272,10 @@ Down navigier runter
 Down navigiere nach unten
 Down navigiere runter
 Down runter
+DownloadSubtitles download Untertitel
+DownloadSubtitles download Untertitel umschalten
+DownloadSubtitles suchen nach Untertitel
+DownloadSubtitles suchen nach Untertitel umschalten
 EjectMedia Scheibe auswerfen
 EjectMedia audio cd auswerfen
 EjectMedia audio disc auswerfen

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -65,6 +65,10 @@ CurrentPlayItemTimeRemaining when will this end
 Down down
 Down go down
 Down navigate down
+DownloadSubtitles download subtitle language
+DownloadSubtitles download subtitles
+DownloadSubtitles search for subtitle language
+DownloadSubtitles search for subtitles
 EjectMedia eject
 EjectMedia eject audio disc
 EjectMedia eject blu-ray

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -37,6 +37,7 @@ SubtitlesOn Untertitel (an/anschalten)
 SubtitlesOff Untertitel (aus/ausschalten)
 SubtitlesNext (nächster Untertitel/Untertitel umschalten)
 SubtitlesPrevious voriger Untertitel
+DownloadSubtitles (download/suchen nach) (Untertitel/Untertitel umschalten)
 
 AudioStreamNext (audio Stream/Sprache) umschalten
 AudioStreamNext (nächster audio Stream/nächste Sprache)

--- a/utterances.txt
+++ b/utterances.txt
@@ -43,6 +43,7 @@ SubtitlesOn (enable/turn on) subtitles
 SubtitlesOff (disable/turn off) subtitles
 SubtitlesNext (next/switch) (subtitles/subtitle language)
 SubtitlesPrevious previous (subtitles/subtitle language)
+DownloadSubtitles (download/search for) (subtitles/subtitle language)
 
 AudioStreamNext (next/switch) audio (/stream)
 AudioStreamNext (next/switch) (/audio) language


### PR DESCRIPTION
Added an intent for downloading subtitles. When playing a show or movie, this will open the "Download subtitles" window, where you can download a subtitle from one of your enabled subtitle addons. I prefer to enable the Kodi setting "Automatically download the first subtitle" in order to download subtitles with just 1 voice command. Alternatively, this requires a "Select" command to download a subtitle.
(Related to issue #49 )