### PR TITLE
Support for specifying artist when asking for a music video

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Here are some of the features supported by this skill:
 - Play a specific song
 - Play/Shuffle audio and video playlists
 - "Party mode" for music (shuffle all)
+- Play/Shuffle music videos
+- Play/Shuffle music videos from a specific genre
+- Play/Shuffle music videos by a specific artist
 - Shuffle all episodes of a TV show
 - Play random TV show
 - Play random TV show from a specific genre

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn
 pytz
 flask-ask>=0.8.9
-kodi-voice>=0.9.7
+kodi-voice>=0.9.8

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -389,6 +389,10 @@
         {
           "name": "MusicVideo",
           "type": "MUSICVIDEOS"
+        },
+        {
+          "name": "Artist",
+          "type": "MUSICARTISTS"
         }
       ]
     },
@@ -398,6 +402,10 @@
         {
           "name": "MusicVideoGenre",
           "type": "MUSICVIDEOGENRES"
+        },
+        {
+          "name": "Artist",
+          "type": "MUSICARTISTS"
         }
       ]
     },
@@ -416,6 +424,10 @@
         {
           "name": "MusicVideoGenre",
           "type": "MUSICVIDEOGENRES"
+        },
+        {
+          "name": "Artist",
+          "type": "MUSICARTISTS"
         }
       ]
     },

--- a/speech_assets/SampleUtterances.german.txt
+++ b/speech_assets/SampleUtterances.german.txt
@@ -902,12 +902,22 @@ ShuffleLatestAlbum starte Zufallswiedergabe des neuen Albums von {Artist}
 ShuffleLatestAlbum starte Zufallswiedergabe des neuesten Albums von {Artist}
 ShuffleLatestAlbum starte Zufallswiedergabe des zuletzt hinzugefügten Albums von {Artist}
 ShuffleMedia zufallswiedergabe {Show}
-ShuffleMusicVideos zeige Musikvideos
+ShuffleMusicVideos spiele alle Musikvideos
+ShuffleMusicVideos spiele alle Musikvideos von {Artist}
+ShuffleMusicVideos spiele alle {MusicVideoGenre} Musikvideos
+ShuffleMusicVideos spiele alle {MusicVideoGenre} Musikvideos von {Artist}
+ShuffleMusicVideos spiele zufällige Musikvideos
+ShuffleMusicVideos spiele zufällige Musikvideos von {Artist}
+ShuffleMusicVideos spiele zufällige {MusicVideoGenre} Musikvideos
+ShuffleMusicVideos spiele zufällige {MusicVideoGenre} Musikvideos von {Artist}
 ShuffleMusicVideos zeige alle Musikvideos
+ShuffleMusicVideos zeige alle Musikvideos von {Artist}
 ShuffleMusicVideos zeige alle {MusicVideoGenre} Musikvideos
+ShuffleMusicVideos zeige alle {MusicVideoGenre} Musikvideos von {Artist}
 ShuffleMusicVideos zeige zufällige Musikvideos
+ShuffleMusicVideos zeige zufällige Musikvideos von {Artist}
 ShuffleMusicVideos zeige zufällige {MusicVideoGenre} Musikvideos
-ShuffleMusicVideos zeige {MusicVideoGenre} Musikvideos
+ShuffleMusicVideos zeige zufällige {MusicVideoGenre} Musikvideos von {Artist}
 ShufflePlaylist zufallswiedergabe playlist {AudioPlaylist}
 ShufflePlaylist zufallswiedergabe playlist {VideoPlaylist}
 ShufflePlaylist zufallswiedergabe {AudioPlaylist} playlist
@@ -1108,7 +1118,9 @@ WatchMovieTrailer zeige Vorschau
 WatchMovieTrailer zeige Vorschau für {Movie}
 WatchMovieTrailer zeige Vorschau von {Movie}
 WatchMusicVideo zeige Musikvideo {MusicVideo}
+WatchMusicVideo zeige Musikvideo {MusicVideo} von {Artist}
 WatchMusicVideo zeige das Musikvideo {MusicVideo}
+WatchMusicVideo zeige das Musikvideo {MusicVideo} von {Artist}
 WatchNextEpisode zeige nächste Episode von {Show}
 WatchNextEpisode zeige nächste Folge von {Show}
 WatchRandomEpisode zeige eine Episode von {Show}
@@ -1119,10 +1131,22 @@ WatchRandomMovie zeige Film
 WatchRandomMovie zeige zufälligen Film
 WatchRandomMovie zeige zufälligen {MovieGenre} Film
 WatchRandomMovie zeige {MovieGenre} Film
-WatchRandomMusicVideo zeige ein Musikvideo
+WatchRandomMusicVideo spiele ein zufälliges Musikvideo
+WatchRandomMusicVideo spiele ein zufälliges Musikvideo von {Artist}
+WatchRandomMusicVideo spiele ein zufälliges {MusicVideoGenre} Musikvideo
+WatchRandomMusicVideo spiele ein zufälliges {MusicVideoGenre} Musikvideo von {Artist}
+WatchRandomMusicVideo spiele zufälliges Musikvideo
+WatchRandomMusicVideo spiele zufälliges Musikvideo von {Artist}
+WatchRandomMusicVideo spiele zufälliges {MusicVideoGenre} Musikvideo
+WatchRandomMusicVideo spiele zufälliges {MusicVideoGenre} Musikvideo von {Artist}
 WatchRandomMusicVideo zeige ein zufälliges Musikvideo
+WatchRandomMusicVideo zeige ein zufälliges Musikvideo von {Artist}
 WatchRandomMusicVideo zeige ein zufälliges {MusicVideoGenre} Musikvideo
-WatchRandomMusicVideo zeige ein {MusicVideoGenre} Musikvideo
+WatchRandomMusicVideo zeige ein zufälliges {MusicVideoGenre} Musikvideo von {Artist}
+WatchRandomMusicVideo zeige zufälliges Musikvideo
+WatchRandomMusicVideo zeige zufälliges Musikvideo von {Artist}
+WatchRandomMusicVideo zeige zufälliges {MusicVideoGenre} Musikvideo
+WatchRandomMusicVideo zeige zufälliges {MusicVideoGenre} Musikvideo von {Artist}
 WatchRandomShow zeige eine Serie
 WatchRandomShow zeige eine zufällige Serie
 WatchRandomShow zeige eine zufällige {ShowGenre} Serie

--- a/speech_assets/SampleUtterances.txt
+++ b/speech_assets/SampleUtterances.txt
@@ -623,17 +623,29 @@ ShuffleLatestAlbum shuffle the latest album by {Artist}
 ShuffleLatestAlbum shuffle the newest album by {Artist}
 ShuffleMedia shuffle {Show}
 ShuffleMusicVideos play all music videos
+ShuffleMusicVideos play all music videos by {Artist}
 ShuffleMusicVideos play all {MusicVideoGenre} music videos
+ShuffleMusicVideos play all {MusicVideoGenre} music videos by {Artist}
 ShuffleMusicVideos play music videos
+ShuffleMusicVideos play music videos by {Artist}
 ShuffleMusicVideos play {MusicVideoGenre} music videos
+ShuffleMusicVideos play {MusicVideoGenre} music videos by {Artist}
 ShuffleMusicVideos shuffle all music videos
+ShuffleMusicVideos shuffle all music videos by {Artist}
 ShuffleMusicVideos shuffle all {MusicVideoGenre} music videos
+ShuffleMusicVideos shuffle all {MusicVideoGenre} music videos by {Artist}
 ShuffleMusicVideos shuffle music videos
+ShuffleMusicVideos shuffle music videos by {Artist}
 ShuffleMusicVideos shuffle {MusicVideoGenre} music videos
+ShuffleMusicVideos shuffle {MusicVideoGenre} music videos by {Artist}
 ShuffleMusicVideos watch all music videos
+ShuffleMusicVideos watch all music videos by {Artist}
 ShuffleMusicVideos watch all {MusicVideoGenre} music videos
+ShuffleMusicVideos watch all {MusicVideoGenre} music videos by {Artist}
 ShuffleMusicVideos watch music videos
+ShuffleMusicVideos watch music videos by {Artist}
 ShuffleMusicVideos watch {MusicVideoGenre} music videos
+ShuffleMusicVideos watch {MusicVideoGenre} music videos by {Artist}
 ShufflePlaylist shuffle playlist {AudioPlaylist}
 ShufflePlaylist shuffle playlist {VideoPlaylist}
 ShufflePlaylist shuffle the playlist {AudioPlaylist}
@@ -981,9 +993,13 @@ WatchMovieTrailer watch the trailer for {Movie}
 WatchMovieTrailer watch trailer
 WatchMovieTrailer watch trailer for {Movie}
 WatchMusicVideo play music video {MusicVideo}
+WatchMusicVideo play music video {MusicVideo} by {Artist}
 WatchMusicVideo play the music video {MusicVideo}
+WatchMusicVideo play the music video {MusicVideo} by {Artist}
 WatchMusicVideo watch music video {MusicVideo}
+WatchMusicVideo watch music video {MusicVideo} by {Artist}
 WatchMusicVideo watch the music video {MusicVideo}
+WatchMusicVideo watch the music video {MusicVideo} by {Artist}
 WatchNextEpisode play next episode of {Show}
 WatchNextEpisode play the next episode of {Show}
 WatchNextEpisode watch next episode of {Show}
@@ -1009,13 +1025,21 @@ WatchRandomMovie watch random movie
 WatchRandomMovie watch random {MovieGenre} film
 WatchRandomMovie watch random {MovieGenre} movie
 WatchRandomMusicVideo play a random music video
+WatchRandomMusicVideo play a random music video by {Artist}
 WatchRandomMusicVideo play a random {MusicVideoGenre} music video
+WatchRandomMusicVideo play a random {MusicVideoGenre} music video by {Artist}
 WatchRandomMusicVideo play random music video
+WatchRandomMusicVideo play random music video by {Artist}
 WatchRandomMusicVideo play random {MusicVideoGenre} music video
+WatchRandomMusicVideo play random {MusicVideoGenre} music video by {Artist}
 WatchRandomMusicVideo watch a random music video
+WatchRandomMusicVideo watch a random music video by {Artist}
 WatchRandomMusicVideo watch a random {MusicVideoGenre} music video
+WatchRandomMusicVideo watch a random {MusicVideoGenre} music video by {Artist}
 WatchRandomMusicVideo watch random music video
+WatchRandomMusicVideo watch random music video by {Artist}
 WatchRandomMusicVideo watch random {MusicVideoGenre} music video
+WatchRandomMusicVideo watch random {MusicVideoGenre} music video by {Artist}
 WatchRandomShow play a random show
 WatchRandomShow play a random t. v. show
 WatchRandomShow play a random {ShowGenre} show

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -94,8 +94,6 @@ playing_episode_number: "Spiele die Staffel {{ season }} Folge {{ episode }} von
 
 playing_action_episode_number: "{{ action }} Staffel {{ season }} Folge {{ episode }} von {{ show_name }}"
 
-playing_genre_musicvideo: "Spiele das {{ genre_name }} Musikvideo {{ musicvideo_name }} von {{ artist_name }}"
-
 playing_musicvideo: "Spiele das Musikvideo {{ musicvideo_name }} von {{ artist_name }}"
 
 playing_empty: "Spiele"

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -40,6 +40,14 @@ could_not_find_episode_show: "Konnte Staffel {{ season }} Folge {{ episode }} vo
 
 could_not_find_musicvideo: "Konnte kein Musikvideo mit dem Namen {{ heard_musicvideo }} finden"
 
+could_not_find_musicvideo_artist: "Konnte kein Musikvideo mit dem Titel {{ heard_musicvideo }} von {{ heard_artist }} finden"
+
+could_not_find_musicvideos_genre: "Konnte keine {{ genre_name }} Musikvideos finden"
+
+could_not_find_musicvideos_artist: "Konnte keine Musikvideos von {{ artist_name }} finden"
+
+could_not_find_musicvideos_genre_artist: "Konnte keine {{ genre_name }} Musikvideos von {{ artist_name }} finden"
+
 no_recommendations: "Es tut mir leid, aber es gibt nichts zu empfehlen."
 
 recommend_movie: "Wie wäre es mit dem Film {{ movie_name }}?"
@@ -335,9 +343,17 @@ shuffling_musicvideos: "Spiele zufällige Musikvideos"
 
 shuffling_musicvideos_genre: "Spiele zufällige {{ genre }} Musikvideos"
 
+shuffling_musicvideos_artist: "Zufällige Wiedergabe von Musikvideos von {{ artist }}"
+
+shuffling_musicvideos_genre_artist: "Zufällige Wiedergabe von {{ genre }} Musikvideos von {{ artist }}"
+
 playing_random_musicvideo: "Spiele ein zufälliges Musikvideo"
 
 playing_random_musicvideo_genre: "Spiele ein zufälliges {{ genre }} Musikvideo"
+
+playing_random_musicvideo_artist: "Spiele ein zufälliges Musikvideo von {{ artist }}"
+
+playing_random_musicvideo_genre_artist: "Spiele ein zufälliges {{ genre }} Musikvideo von {{ artist }}"
 
 playing_album_card: "Spiele Album"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -40,6 +40,14 @@ could_not_find_episode_show: "Could not find season {{ season }} episode {{ epis
 
 could_not_find_musicvideo: "Could not find a music video called {{ heard_musicvideo }}"
 
+could_not_find_musicvideo_artist: "Could not find a music video called {{ heard_musicvideo }} by {{ heard_artist }}"
+
+could_not_find_musicvideos_genre: "Could not find any {{ genre_name }} music videos"
+
+could_not_find_musicvideos_artist: "Could not find any music videos by {{ artist_name }}"
+
+could_not_find_musicvideos_genre_artist: "Could not find any {{ genre_name }} music videos by {{ artist_name }}"
+
 no_recommendations: "I'm sorry, I have nothing to recommend"
 
 recommend_movie: "How about the movie {{ movie_name }}?"
@@ -93,8 +101,6 @@ playing_trailer: "Playing the trailer for {{ heard_name }}"
 playing_episode_number: "Playing season {{ season }} episode {{ episode }} of {{ show_name }}"
 
 playing_action_episode_number: "{{ action }} season {{ season }} episode {{ episode }} of {{ show_name }}"
-
-playing_genre_musicvideo: "Playing the {{ genre_name }} music video {{ musicvideo_name }} by {{ artist_name }}"
 
 playing_musicvideo: "Playing the music video {{ musicvideo_name }} by {{ artist_name }}"
 
@@ -337,9 +343,17 @@ shuffling_musicvideos: "Shuffling music videos"
 
 shuffling_musicvideos_genre: "Shuffling {{ genre }} music videos"
 
+shuffling_musicvideos_artist: "Shuffling music videos by {{ artist }}"
+
+shuffling_musicvideos_genre_artist: "Shuffling {{ genre }} music videos by {{ artist }}"
+
 playing_random_musicvideo: "Playing a random music video"
 
 playing_random_musicvideo_genre: "Playing a random {{ genre }} music video"
+
+playing_random_musicvideo_artist: "Playing a random music video by {{ artist }}"
+
+playing_random_musicvideo_genre_artist: "Playing a random {{ genre }} music video by {{ artist }}"
 
 playing_album_card: "Playing album"
 

--- a/utterances.german.txt
+++ b/utterances.german.txt
@@ -144,13 +144,13 @@ WatchLastShow weiter mit (/letzter) Serie
 
 WatchLatestEpisode zeige (neueste/letzte) (Episode/Folge) von {Show}
 
-WatchMusicVideo zeige (/das) Musikvideo {MusicVideo}
+WatchMusicVideo zeige (/das) Musikvideo {MusicVideo} (/von {Artist})
 
-WatchRandomMusicVideo zeige ein (/zufälliges) (/{MusicVideoGenre}) Musikvideo
+WatchRandomMusicVideo (zeige/spiele) (/ein) zufälliges (/{MusicVideoGenre}) Musikvideo (/von {Artist})
 
 ShuffleShow zufallswiedergabe (/aller) episoden von {Show}
 
-ShuffleMusicVideos zeige (/zufällige/alle) (/{MusicVideoGenre}) Musikvideos
+ShuffleMusicVideos (zeige/spiele) (alle/zufällige) (/{MusicVideoGenre}) Musikvideos (/von {Artist})
 
 ShuffleLatestAlbum (shuffle/(/starte) Zufallswiedergabe) des (aktuellen/neuen/aktuellsten/neuesten/zuletzt hinzugefügten) Albums von {Artist}
 

--- a/utterances.txt
+++ b/utterances.txt
@@ -154,9 +154,9 @@ WatchLastShow continue (/watching/playing) (/last/the last) show
 
 WatchLatestEpisode (play/watch) (/the) (newest/latest) episode of {Show}
 
-WatchMusicVideo (play/watch) (/the) music video {MusicVideo}
+WatchMusicVideo (play/watch) (/the) music video {MusicVideo} (/by {Artist})
 
-WatchRandomMusicVideo (play/watch) (/a) random (/{MusicVideoGenre}) music video
+WatchRandomMusicVideo (play/watch) (/a) random (/{MusicVideoGenre}) music video (/by {Artist})
 
 WatchVideoPlaylist (play/watch) (/the) (movie/show/video) playlist {VideoPlaylist}
 WatchVideoPlaylist (play/watch) {VideoPlaylist} (movie/show/video) playlist
@@ -165,7 +165,7 @@ WatchVideoPlaylist watch {VideoPlaylist} playlist
 
 ShuffleShow shuffle (/all) episodes of {Show}
 
-ShuffleMusicVideos (play/watch/shuffle) (/all) (/{MusicVideoGenre}) music videos
+ShuffleMusicVideos (play/watch/shuffle) (/all) (/{MusicVideoGenre}) music videos (/by {Artist})
 
 ShuffleLatestAlbum shuffle (/the) (latest/newest) album by {Artist}
 


### PR DESCRIPTION
Adds the following utterances:

```
WatchMusicVideo (play/watch) (/the) music video {MusicVideo} by {Artist}
ShuffleMusicVideos (play/watch/shuffle) (/all) (/{MusicVideoGenre}) music videos by {Artist}
WatchRandomMusicVideo (play/watch) (/a) random (/{MusicVideoGenre}) music video by {Artist}
```

This has been tested in English, but needs German translations.  Ping @mcl22 and @ausweider.

Requires Kodi-Voice 0.9.8, which has already been pushed up.

Addresses issue #212.