### PR TITLE
Add example utterances to AMAZON.HelpIntent.

### DIFF
--- a/sample_slotvals.de.txt
+++ b/sample_slotvals.de.txt
@@ -1,0 +1,18 @@
+Addon YouTube
+MovieGenre Komödie
+Movie Männertag
+Artist Helene Fischer
+Album Farbenspiel
+MusicGenre Schlager
+AudioPlaylist Partymusik
+Song Atemlos
+Show Farscape
+VideoPlaylist HD videos
+ShowGenre Science Fiction
+MusicVideoGenre Pop
+MusicVideo Die Hölle morgen früh
+Volume Fünfundsiebzig
+Season zwei
+Episode acht
+ForwardDur eine Minute
+BackwardDur 30 Sekunden

--- a/sample_slotvals.en.txt
+++ b/sample_slotvals.en.txt
@@ -1,0 +1,18 @@
+Addon YouTube
+MovieGenre Comedy
+Movie Tropic Thunder
+Artist Sia
+Album One Thousand Forms of Fear
+MusicGenre Pop
+AudioPlaylist Holiday
+Song Elastic Heart
+Show Farscape
+VideoPlaylist HD videos
+ShowGenre Science Fiction
+MusicVideoGenre Pop
+MusicVideo Chandelier
+Volume seventy five
+Season two
+Episode eight
+ForwardDur one minute
+BackwardDur thirty seconds

--- a/speech_assets/SampleUtterances.de.txt
+++ b/speech_assets/SampleUtterances.de.txt
@@ -1,3 +1,7 @@
+AMAZON.HelpIntent nach was ich es fragen kann
+AMAZON.HelpIntent was es alles kann
+AMAZON.HelpIntent was es kann
+AMAZON.HelpIntent was ich es fragen kann
 AddonExecute führe add on {Addon} aus
 AddonExecute führe addon {Addon} aus
 AddonExecute führe erweiterung {Addon} aus

--- a/speech_assets/SampleUtterances.en.txt
+++ b/speech_assets/SampleUtterances.en.txt
@@ -1,3 +1,6 @@
+AMAZON.HelpIntent things to try
+AMAZON.HelpIntent what can i ask you
+AMAZON.HelpIntent what can you do
 AddonExecute execute add on {Addon}
 AddonExecute execute addon {Addon}
 AddonExecute execute plug in {Addon}

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -162,7 +162,15 @@ you_have_episode_list: "Es gibt neue Folgen für {{ items }}"
 
 volume_set: "Lautstärke auf {{ num }} gestellt"
 
-help: "Du kannst mich fragen ob es neue Serien gibt, einen Film, Serie oder Sänger zu spielen, oder die Wiedergabe von Medien zu bedienen"
+help: "Du kannst mich fragen, ob es neue Serien gibt, mich bitten einen Film, eine Serie oder die Musik eines Interpreten abzuspielen oder die Wiedergabe von Medien zu steuern und vieles mehr. Zum Beispiel {{ example }}. Ich habe dir weitere Beispiele an deine Alexa App geschickt."
+
+help_short: "Was möchtest du tun? Probiere etwas wie {{ example }}."
+
+help_text: "Kodi-Alexa ermöglicht es dir eine oder mehrere Kodi Installtionen mit deiner Stimme zu steuern. Hier sind einige Beispiele, die du sagen kannst:\n
+\xa0\n
+{{ example }}
+\xa0\n
+Für eine komplette Liste der unterstützten Kommandos, lese bitte die README Datei auf Github (https://github.com/m0ngr31/kodi-alexa/README.md)."
 
 help_play: "Spezifiziere bitte den Medientyp mit dem Wiedergabebefehl, so wie Spiele den Film Ghost Busters"
 
@@ -175,8 +183,6 @@ are_you_sure_reboot: "Bist du dir sicher, dass du einen Neustart durchführen m�
 are_you_sure_hibernate: "Bist du dir sicher, dass das System in den Hibernate gehen soll?"
 
 are_you_sure_suspend: "Bist du dir sicher, dass das System in den Suspend gehen soll?"
-
-what_to_do: "Was möchtest Du tun?"
 
 welcome: "Willkommen zum Kodi Skill"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -162,7 +162,15 @@ you_have_episode_list: "There are new episodes of {{ items }}"
 
 volume_set: "Volume set to {{ num }}"
 
-help: "You can ask me whether there are any new shows, to play a movie, tv show, or artist, or control playback of media."
+help: "You can ask me whether there are any new shows, to play a movie, t. v. show, or artist, control playback of media, and more. For example, {{ example }}. I've sent more examples to your Alexa app."
+
+help_short: "What would you like to do?  Try something like, {{ example }}."
+
+help_text: "Kodi-Alexa allows you to fully control one or more Kodi installations with your voice.  Here are some examples of things you can say:\n
+\xa0\n
+{{ examples }}
+\xa0\n
+For a complete list of supported requests, please see the README file on Github (https://github.com/m0ngr31/kodi-alexa/README.md)."
 
 help_play: "Please specify the media type in your play command, such as, play the movie ghost busters."
 
@@ -175,8 +183,6 @@ are_you_sure_reboot: "Are you sure you want to reboot?"
 are_you_sure_hibernate: "Are you sure you want to hibernate?"
 
 are_you_sure_suspend: "Are you sure you want to suspend?"
-
-what_to_do: "What would you like to do?"
 
 welcome: "Welcome to Kodi."
 

--- a/utterances.de.txt
+++ b/utterances.de.txt
@@ -254,3 +254,6 @@ AddonGlobalSearch (suche/suche nach/finde) {Show}
 AddonGlobalSearch (suche/suche nach/finde) {Movie}
 AddonGlobalSearch (suche/suche nach/finde) {Album}
 AddonGlobalSearch (suche/suche nach/finde) {Artist}
+
+AMAZON.HelpIntent (/nach) was ich es fragen kann
+AMAZON.HelpIntent was es (/alles) kann

--- a/utterances.en.txt
+++ b/utterances.en.txt
@@ -255,3 +255,6 @@ AddonGlobalSearch (find/search for) {Show}
 AddonGlobalSearch (find/search for) {Movie}
 AddonGlobalSearch (find/search for) {Album}
 AddonGlobalSearch (find/search for) {Artist}
+
+AMAZON.HelpIntent what can (you do/i ask you)
+AMAZON.HelpIntent things to try


### PR DESCRIPTION
This expands the Help response to include random example utterances the user can try.

The spoken response includes one random utterance and another for the reprompt.  The same reprompt is used for `ask.launch` (skill opened with no Intent requested, as in, `open kodi`).

The Card presented in the Alexa app provides 5 randomly-chosen utterances.

The example utterances are chosen from the `speech_assets/SampleUtterances.LANG.txt` file.  A new file `sample_slotvals.LANG.txt` was created to fill slot references with something to make it sound more natural than something like `insert title here`.

_Needs testing for Heroku deployments_