### PR TITLE
Add AudioPassthrough and StereoscopicMode Intents.

### DIFF
--- a/alexa.py
+++ b/alexa.py
@@ -1062,6 +1062,19 @@ def alexa_fullscreen():
   return statement(response_text).simple_card(card_title, response_text)
 
 
+# Handle the StereoscopicMode intent.
+@ask.intent('StereoscopicMode')
+def alexa_stereoscopic_mode():
+  card_title = render_template('toggle_stereoscopic_mode').encode("utf-8")
+  print card_title
+
+  kodi = Kodi(config, context)
+  kodi.ToggleStereoscopicMode()
+  response_text = ""
+
+  return statement(response_text).simple_card(card_title, response_text)
+
+
 # Handle the Mute intent.
 @ask.intent('Mute')
 def alexa_mute():

--- a/alexa.py
+++ b/alexa.py
@@ -1075,6 +1075,19 @@ def alexa_stereoscopic_mode():
   return statement(response_text).simple_card(card_title, response_text)
 
 
+# Handle the AudioPassthrough intent.
+@ask.intent('AudioPassthrough')
+def alexa_audio_passthrough():
+  card_title = render_template('toggle_audio_passthrough').encode("utf-8")
+  print card_title
+
+  kodi = Kodi(config, context)
+  kodi.ToggleAudioPassthrough()
+  response_text = ""
+
+  return statement(response_text).simple_card(card_title, response_text)
+
+
 # Handle the Mute intent.
 @ask.intent('Mute')
 def alexa_mute():

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -581,6 +581,9 @@
       "intent": "Fullscreen"
     },
     {
+      "intent": "StereoscopicMode"
+    },
+    {
       "intent": "Mute"
     },
     {

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -584,6 +584,9 @@
       "intent": "StereoscopicMode"
     },
     {
+      "intent": "AudioPassthrough"
+    },
+    {
       "intent": "Mute"
     },
     {

--- a/speech_assets/SampleUtterances.de.txt
+++ b/speech_assets/SampleUtterances.de.txt
@@ -22,6 +22,21 @@ AddonGlobalSearch suche {Album}
 AddonGlobalSearch suche {Artist}
 AddonGlobalSearch suche {Movie}
 AddonGlobalSearch suche {Show}
+AudioPassthrough aktiviere digital
+AudioPassthrough aktiviere passthrough
+AudioPassthrough schalte Audioausgabe auf digital
+AudioPassthrough schalte Audioausgabe auf digital um
+AudioPassthrough schalte Audioausgabe auf passthrough
+AudioPassthrough schalte Audioausgabe auf passthrough um
+AudioPassthrough schalte Audioausgabe um
+AudioPassthrough schalte auf digital
+AudioPassthrough schalte auf digital um
+AudioPassthrough schalte auf passthrough
+AudioPassthrough schalte auf passthrough um
+AudioPassthrough schalte digital
+AudioPassthrough schalte digital um
+AudioPassthrough schalte passthrough
+AudioPassthrough schalte passthrough um
 AudioStreamNext Sprache umschalten
 AudioStreamNext audio Stream umschalten
 AudioStreamNext nächste Sprache
@@ -938,6 +953,12 @@ Shutdown herunterfahren
 Shutdown shutdown
 Shutdown system herunterfahren
 Shutdown system shutdown
+StereoscopicMode aktiviere 3D
+StereoscopicMode aktiviere 3D Modus
+StereoscopicMode schalte auf 3D
+StereoscopicMode schalte auf 3D Modus
+StereoscopicMode schalte auf 3D Modus um
+StereoscopicMode schalte auf 3D um
 SubtitlesDownload download Untertitel
 SubtitlesNext Untertitel umschalten
 SubtitlesNext nächster Untertitel

--- a/speech_assets/SampleUtterances.en.txt
+++ b/speech_assets/SampleUtterances.en.txt
@@ -706,6 +706,8 @@ ShuffleVideoPlaylist shuffle {VideoPlaylist} show playlist
 ShuffleVideoPlaylist shuffle {VideoPlaylist} video playlist
 Shutdown shut down
 Shutdown shut down system
+StereoscopicMode toggle stereoscopic mode
+StereoscopicMode toggle three d. mode
 SubtitlesDownload download subtitles
 SubtitlesNext next subtitle language
 SubtitlesNext next subtitles

--- a/speech_assets/SampleUtterances.en.txt
+++ b/speech_assets/SampleUtterances.en.txt
@@ -33,6 +33,10 @@ AddonGlobalSearch search for {Album}
 AddonGlobalSearch search for {Artist}
 AddonGlobalSearch search for {Movie}
 AddonGlobalSearch search for {Show}
+AudioPassthrough toggle audio passthrough
+AudioPassthrough toggle digital audio
+AudioPassthrough toggle digital passthrough
+AudioPassthrough toggle passthrough audio
 AudioStreamNext next audio
 AudioStreamNext next audio language
 AudioStreamNext next audio stream

--- a/templates.de.yaml
+++ b/templates.de.yaml
@@ -303,6 +303,8 @@ subtitles_enable: "Untertitel einschalten"
 
 subtitles_download: "Herunterladen von Untertiteln"
 
+toggle_audio_passthrough: "Schalte Audio Passthrough um"
+
 adjusting_volume: "Lautstärke anpassen"
 
 volume_down: "Lautstärke verringern"
@@ -312,6 +314,8 @@ volume_up: "Lautstärke erhöhen"
 mute_unmute: "Stummschalten"
 
 toggle_fullscreen: "Vollbild umschalten"
+
+toggle_stereoscopic_mode: "Schalte 3D Modus um"
 
 playing_previous: "Spiele vorherigen Titel"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -303,6 +303,8 @@ subtitles_enable: "Enabling subtitles"
 
 subtitles_download: "Downloading subtitles"
 
+toggle_audio_passthrough: "Toggling audio passthrough"
+
 adjusting_volume: "Adjusting volume"
 
 volume_down: "Turning volume down"

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -313,6 +313,8 @@ mute_unmute: "Toggling mute"
 
 toggle_fullscreen: "Toggling fullscreen"
 
+toggle_stereoscopic_mode: "Toggling stereoscopic mode"
+
 playing_previous: "Playing previous item"
 
 playing_next: "Playing next item"

--- a/utterances.de.txt
+++ b/utterances.de.txt
@@ -46,7 +46,13 @@ ViewPlaylist (öffne/gehe zu) playlist {VideoPlaylist}
 ViewPlaylist (öffne/gehe zu) {VideoPlaylist} playlist
 
 Fullscreen vollbild (/umschalten)
+StereoscopicMode schalte auf 3D (/Modus) (/um)
+StereoscopicMode aktiviere 3D (/Modus)
 
+AudioPassthrough schalte (/Audioausgabe) auf (passthrough/digital) (/um)
+AudioPassthrough schalte Audioausgabe um
+AudioPassthrough schalte (passthrough/digital) (/um)
+AudioPassthrough aktiviere (passthrough/digital)
 Mute ton (aus/an)(/schalten)
 VolumeUp lauter
 VolumeDown leiser

--- a/utterances.en.txt
+++ b/utterances.en.txt
@@ -54,6 +54,7 @@ ViewPlaylist (open/go to/show) (/the) playlist {VideoPlaylist}
 ViewPlaylist (open/go to/show) {VideoPlaylist} playlist
 
 Fullscreen (/toggle) (fullscreen/visualizer)
+StereoscopicMode toggle (stereoscopic/three d.) mode
 
 Mute (/toggle/set) (mute/unmute)
 VolumeUp (/turn) volume up

--- a/utterances.en.txt
+++ b/utterances.en.txt
@@ -56,6 +56,8 @@ ViewPlaylist (open/go to/show) {VideoPlaylist} playlist
 Fullscreen (/toggle) (fullscreen/visualizer)
 StereoscopicMode toggle (stereoscopic/three d.) mode
 
+AudioPassthrough toggle (passthrough/digital) audio
+AudioPassthrough toggle (digital/audio) passthrough
 Mute (/toggle/set) (mute/unmute)
 VolumeUp (/turn) volume up
 VolumeUp (/turn) up volume


### PR DESCRIPTION
Pretty self-explanatory: adds commands to toggle digital audio passthrough and stereoscopic (3D) mode.

Addresses Issue #217.

Requires changes to Kodi-Voice that have been pushed up, but not yet released.  Awaiting confirmation of resolution for https://github.com/m0ngr31/kodi-voice/issues/18