### PR TITLE
Added delaying/advancing subtitles with voice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,9 @@ MUSICVIDEOGENRES
 ADDONS
 
 kodi-alexa/
-run.sh
 
 zappa_settings.json
 templates.yaml
+
+*~
+*.sh

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Most everything you can do with a remote or keyboard is supported in the skill, 
 - "What's playing?" functionality for music, movies, and shows
 - Report time remaining on current media and when it will end
 - Cycle through audio and subtitle streams
+- Download subtitles
+- Delay/advance subtitles
 - Search for something in your library (**requires script.globalsearch addon**)
 - Execute addons
 - Shutdown/reboot/sleep/hibernate system

--- a/alexa.py
+++ b/alexa.py
@@ -1248,7 +1248,7 @@ def alexa_subtitles_delay(kodi):
   card_title = render_template('subtitles_delay').encode('utf-8')
   log.info(card_title)
 
-  item = kodi.DelaySubtitles()
+  item = kodi.DelaySubtitles(0.5)
   return statement(card_title).simple_card(card_title, '')
 
 
@@ -1259,7 +1259,7 @@ def alexa_subtitles_advance(kodi):
   card_title = render_template('subtitles_advance').encode('utf-8')
   log.info(card_title)
 
-  item = kodi.AdvanceSubtitles()
+  item = kodi.AdvanceSubtitles(0.5)
   return statement(card_title).simple_card(card_title, '')
 
 
@@ -1267,7 +1267,10 @@ def alexa_subtitles_advance(kodi):
 @ask.intent('SubtitlesDelayBy')
 @preflight_check
 def alexa_subtitles_delay_by(kodi, Delay):
-  card_title = render_template('subtitles_delay_by', num=Delay).encode('utf-8')
+  if float(Delay) == 1:
+    card_title = render_template('subtitles_delay_by1').encode('utf-8')
+  else:
+    card_title = render_template('subtitles_delay_by', num=Delay).encode('utf-8')
   log.info(card_title)
 
   item = kodi.DelaySubtitles(float(Delay))
@@ -1278,7 +1281,10 @@ def alexa_subtitles_delay_by(kodi, Delay):
 @ask.intent('SubtitlesAdvanceBy')
 @preflight_check
 def alexa_subtitles_advance_by(kodi, Advance):
-  card_title = render_template('subtitles_advance_by', num=Advance).encode('utf-8')
+  if float(Advance) == 1:
+    card_title = render_template('subtitles_advance_by1').encode('utf-8')
+  else:
+    card_title = render_template('subtitles_advance_by', num=Advance).encode('utf-8')
   log.info(card_title)
 
   item = kodi.AdvanceSubtitles(float(Advance))

--- a/alexa.py
+++ b/alexa.py
@@ -1263,6 +1263,28 @@ def alexa_subtitles_advance(kodi):
   return statement(card_title).simple_card(card_title, '')
 
 
+# Handle the SubtitlesDelayBy intent.
+@ask.intent('SubtitlesDelayBy')
+@preflight_check
+def alexa_subtitles_delay_by(kodi, Delay):
+  card_title = render_template('subtitles_delay_by', num=Delay).encode('utf-8')
+  log.info(card_title)
+
+  item = kodi.DelaySubtitles(float(Delay))
+  return statement(card_title).simple_card(card_title, '')
+
+
+# Handle the SubtitlesAdvanceBy intent.
+@ask.intent('SubtitlesAdvanceBy')
+@preflight_check
+def alexa_subtitles_advance_by(kodi, Advance):
+  card_title = render_template('subtitles_advance_by', num=Advance).encode('utf-8')
+  log.info(card_title)
+
+  item = kodi.AdvanceSubtitles(float(Advance))
+  return statement(card_title).simple_card(card_title, '')
+
+
 # Handle the AudioStreamNext intent.
 @ask.intent('AudioStreamNext')
 @preflight_check

--- a/alexa.py
+++ b/alexa.py
@@ -1249,7 +1249,7 @@ def alexa_subtitles_delay(kodi):
   log.info(card_title)
 
   item = kodi.DelaySubtitles(0.5)
-  return statement(card_title).simple_card(card_title, '')
+  return statement('').simple_card(card_title, '')
 
 
 # Handle the SubtitlesAdvance intent.
@@ -1260,7 +1260,7 @@ def alexa_subtitles_advance(kodi):
   log.info(card_title)
 
   item = kodi.AdvanceSubtitles(0.5)
-  return statement(card_title).simple_card(card_title, '')
+  return statement('').simple_card(card_title, '')
 
 
 # Handle the SubtitlesDelayBy intent.
@@ -1274,7 +1274,7 @@ def alexa_subtitles_delay_by(kodi, Delay):
   log.info(card_title)
 
   item = kodi.DelaySubtitles(float(Delay))
-  return statement(card_title).simple_card(card_title, '')
+  return statement('').simple_card(card_title, '')
 
 
 # Handle the SubtitlesAdvanceBy intent.
@@ -1288,7 +1288,7 @@ def alexa_subtitles_advance_by(kodi, Advance):
   log.info(card_title)
 
   item = kodi.AdvanceSubtitles(float(Advance))
-  return statement(card_title).simple_card(card_title, '')
+  return statement('').simple_card(card_title, '')
 
 
 # Handle the AudioStreamNext intent.

--- a/alexa.py
+++ b/alexa.py
@@ -1241,6 +1241,28 @@ def alexa_subtitles_download(kodi):
   return statement(card_title).simple_card(card_title, '')
 
 
+# Handle the SubtitlesDelay intent.
+@ask.intent('SubtitlesDelay')
+@preflight_check
+def alexa_subtitles_delay(kodi):
+  card_title = render_template('subtitles_delay').encode('utf-8')
+  log.info(card_title)
+
+  item = kodi.DelaySubtitles()
+  return statement(card_title).simple_card(card_title, '')
+
+
+# Handle the SubtitlesAdvance intent.
+@ask.intent('SubtitlesAdvance')
+@preflight_check
+def alexa_subtitles_advance(kodi):
+  card_title = render_template('subtitles_advance').encode('utf-8')
+  log.info(card_title)
+
+  item = kodi.AdvanceSubtitles()
+  return statement(card_title).simple_card(card_title, '')
+
+
 # Handle the AudioStreamNext intent.
 @ask.intent('AudioStreamNext')
 @preflight_check

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -671,6 +671,12 @@
       "intent": "SubtitlesDownload"
     },
     {
+      "intent": "SubtitlesDelay"
+    },
+    {
+      "intent": "SubtitlesAdvance"
+    },
+    {
       "intent": "AudioStreamNext"
     },
     {

--- a/speech_assets/IntentSchema.json
+++ b/speech_assets/IntentSchema.json
@@ -677,6 +677,24 @@
       "intent": "SubtitlesAdvance"
     },
     {
+      "intent": "SubtitlesDelayBy",
+      "slots": [
+        {
+          "name": "Delay",
+          "type": "AMAZON.NUMBER"
+        }
+      ]
+    },
+    {
+      "intent": "SubtitlesAdvanceBy",
+      "slots": [
+        {
+          "name": "Advance",
+          "type": "AMAZON.NUMBER"
+        }
+      ]
+    },
+    {
       "intent": "AudioStreamNext"
     },
     {

--- a/speech_assets/SampleUtterances.en.txt
+++ b/speech_assets/SampleUtterances.en.txt
@@ -1065,6 +1065,8 @@ SubtitlesOn enable subtitles
 SubtitlesOn turn on subtitles
 SubtitlesPrevious previous subtitle language
 SubtitlesPrevious previous subtitles
+SubtitlesDelay delay subtitles
+SubtitlesAdvance advance subtitles
 Suspend go to sleep
 Suspend put system to sleep
 Suspend sleep

--- a/speech_assets/SampleUtterances.en.txt
+++ b/speech_assets/SampleUtterances.en.txt
@@ -1067,6 +1067,14 @@ SubtitlesPrevious previous subtitle language
 SubtitlesPrevious previous subtitles
 SubtitlesDelay delay subtitles
 SubtitlesAdvance advance subtitles
+SubtitlesAdvanceBy advance subtitles by {Advance}
+SubtitlesAdvanceBy advance subtitles by {Advance} seconds
+SubtitlesAdvanceBy advance subtitles {Advance}
+SubtitlesAdvanceBy advance subtitles {Advance} seconds
+SubtitlesDelayBy delay subtitles by {Delay}
+SubtitlesDelayBy delay subtitles by {Delay} seconds
+SubtitlesDelayBy delay subtitles {Delay}
+SubtitlesDelayBy delay subtitles {Delay} seconds
 Suspend go to sleep
 Suspend put system to sleep
 Suspend sleep

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -311,6 +311,10 @@ subtitles_enable: "Enabling subtitles"
 
 subtitles_download: "Downloading subtitles"
 
+subtitles_delay: "Delaying subtitles by one second"
+
+subtitles_advance: "Advancing subtitles by one second"
+
 toggle_audio_passthrough: "Toggling audio passthrough"
 
 adjusting_volume: "Adjusting volume"

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -313,7 +313,11 @@ subtitles_download: "Downloading subtitles"
 
 subtitles_delay: "Delaying subtitles by one second"
 
+subtitles_delay_by: "Delaying subtitles by {{ num }} seconds"
+
 subtitles_advance: "Advancing subtitles by one second"
+
+subtitles_advance_by: "Advancing subtitles by {{ num }} seconds"
 
 toggle_audio_passthrough: "Toggling audio passthrough"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -311,11 +311,15 @@ subtitles_enable: "Enabling subtitles"
 
 subtitles_download: "Downloading subtitles"
 
-subtitles_delay: "Delaying subtitles by one second"
+subtitles_delay: "Delaying subtitles by half a second"
+
+subtitles_delay_by1: "Delaying subtitles by a second"
 
 subtitles_delay_by: "Delaying subtitles by {{ num }} seconds"
 
-subtitles_advance: "Advancing subtitles by one second"
+subtitles_advance: "Advancing subtitles by half a second"
+
+subtitles_advance_by1: "Advancing subtitles by a second"
 
 subtitles_advance_by: "Advancing subtitles by {{ num }} seconds"
 

--- a/templates.en.yaml
+++ b/templates.en.yaml
@@ -190,7 +190,7 @@ are_you_sure_hibernate: "Are you sure you want to hibernate?"
 
 are_you_sure_suspend: "Are you sure you want to suspend?"
 
-welcome: "Welcome to Kodi."
+welcome: "Here's Kodi."
 
 nothing_currently_playing: "Kodi isn't playing any music right now."
 

--- a/utterances.en.txt
+++ b/utterances.en.txt
@@ -72,6 +72,8 @@ SubtitlesOff (disable/turn off) subtitles
 SubtitlesNext (next/switch) (subtitles/subtitle language)
 SubtitlesPrevious previous (subtitles/subtitle language)
 SubtitlesDownload download subtitles
+SubtitlesDelay delay subtitles
+SubtitlesAdvance advance subtitles
 
 AudioStreamNext (next/switch) audio (/stream)
 AudioStreamNext (next/switch) (/audio) language

--- a/utterances.en.txt
+++ b/utterances.en.txt
@@ -74,6 +74,8 @@ SubtitlesPrevious previous (subtitles/subtitle language)
 SubtitlesDownload download subtitles
 SubtitlesDelay delay subtitles
 SubtitlesAdvance advance subtitles
+SubtitlesDelayBy delay subtitles (/by) {Delay} (/seconds)
+SubtitlesAdvanceBy advance subtitles (/by) {Advance} (/seconds)
 
 AudioStreamNext (next/switch) audio (/stream)
 AudioStreamNext (next/switch) (/audio) language

--- a/whatisplaying.py
+++ b/whatisplaying.py
@@ -1,0 +1,16 @@
+import re
+import string
+import random
+import os
+import time
+from kodi_voice import KodiConfigParser, Kodi
+
+config_file = os.path.join(os.path.dirname(__file__), "kodi.config")
+config = KodiConfigParser(config_file)
+
+kodi = Kodi(config)
+
+print kodi.GetActivePlayItem(),"\n"
+print kodi.GetActivePlayProperties(),"\n"
+#time.sleep(5)
+


### PR DESCRIPTION
Now you can delay/advance through Alexa. Default delay is 500ms ("delay/advance subtitles") or you can say "delay/advance subtitles by two seconds". Works better for me than using +/- on remotes as it is not consistent which one delays and which one advances subtitles. With voice its easier and consistent.