### PR TITLE
Fix 'requirements.txt' git:// repo URIs (unsupported), switch to https://.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn
 pytz
-git+git://github.com/johnwheeler/flask-ask@master#egg=flask-ask
-git+git://github.com/m0ngr31/kodi-voice@master#egg=kodi-voice
+git+https://github.com/johnwheeler/flask-ask@master#egg=flask-ask
+git+https://github.com/m0ngr31/kodi-voice@master#egg=kodi-voice
 cryptography==2.1.4


### PR DESCRIPTION
While working on making deploy to Heroku work again (PR to follow soon), build fails due to `git://` protocol no longer supported. Just switching requirements from `git://` to `https://` and worked like a charm.
@m0ngr31 : After testing it a bit, I'll send a fix to Heroku deployment, which is currently failing. Stay tuned :grin:.