### PR TITLE
Fix the 'Deploy to Heroku' button.

### DIFF
--- a/app.json
+++ b/app.json
@@ -123,5 +123,6 @@
       "required": false
     }
   },
-  "image": "heroku/python"
+  "image": "heroku/python",
+  "stack": "heroku-18"
 }


### PR DESCRIPTION
Although the deploy to Heroku succeeds, you need to manually set the stack for the application:
``` shell
heroku stack:set heroku-18
```
Since the `heroku-18` stack is now required, set it explicitly in the `app.json` file for the 'Deploy to Heroku' button to work.